### PR TITLE
docs(readme): add hardware validation platform table

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,20 @@ Every function is reentrant, allocation-free, and returns a typed status code. T
 
 ---
 
+## Hardware validation
+
+All results are device-run, per-formula values with measured error margins — not simulation. Full tables: [`validation/results/`](validation/results/).
+
+| Platform | Toolchain | Modules | Tests |
+|---|---|---|---|
+| x86-64 — Intel i7-13700H / Ubuntu 22.04 | gcc 11.4.0 -O2 / float32 | 13 / 13 | 300 / 300 ✅ |
+| ARM64 — Apple M4 Pro / macOS | Apple clang -O2 / float32 | 13 / 13 | 300 / 300 ✅ |
+| ESP32-S3 — Xtensa LX7 / ESP-IDF v5.5.2 | xtensa-esp32s3-elf-gcc -O2 / float32 | 8 / 13 | 308 / 308 ✅ |
+
+ESP32-S3 results for autodiff, compressed_sensing, fft, signal, and sketch are in progress.
+
+---
+
 ## Quick start
 
 ```bash


### PR DESCRIPTION
Adds a Hardware validation section to the README reflecting the three validated platforms now that ESP32-S3 results (PR #15) have landed on dev.