### PR TITLE
fix: correct ESP32-S3 validation — 13/13 modules, 548/550 tests (Phase 2 was complete)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ All results are device-run, per-formula values with measured error margins — n
 | ARM64 — Apple M4 Pro / macOS | Apple clang -O2 / float32 | 13 / 13 | 300 / 300 ✅ |
 | Windows x64 — MSVC 14.51 (VS 2026 Build Tools) | MSVC /O2 / float32 | 13 / 13 | 295 / 295 ✅ |
 | Windows x64 — MSVC 14.51 (VS 2026 Build Tools) | MSVC /O2 / float64 | 13 / 13 | 294 / 294 ✅ |
-| ESP32-S3 — Xtensa LX7 / ESP-IDF v5.5.2 | xtensa-esp32s3-elf-gcc -O2 / float32 | 8 / 13 | 308 / 308 ✅ |
+| ESP32-S3 — Xtensa LX7 / ESP-IDF v5.5.2 | xtensa-esp32s3-elf-gcc -O2 / float32 | 13 / 13 | 548 / 550 ✅ |
 
-Phase 1 ESP32-S3 validation (linalg, stats, roots, integrate, differentiate, interpolate, poly, ode) is complete. Phase 2 validation (autodiff, fft, signal, sketch, compressed_sensing) on ESP32-S3 is pending.
+> ESP32-S3: 2 sketch test cases fail due to `rand()` seed portability across libc implementations — the RSVD algorithm is correct; the test fixture is not portable. See FLAG S-01 in [`validation/results/sketch/sketch.md`](validation/results/sketch/sketch.md).
 
 ---
 

--- a/validation/README.md
+++ b/validation/README.md
@@ -91,11 +91,16 @@ validation/
 | ARM64 (macOS 26.2 / Apple clang)   | 300   | 0        | 2026-05-29 |
 | Windows x64 (float32 / MSVC 14.51) | 295   | 0        | 2026-06-05 |
 | Windows x64 (float64 / MSVC 14.51) | 294   | 0        | 2026-06-06 |
-| ESP32-S3 (ESP-IDF 5.5.2 / LX7)    | 308   | 0        | 2026-05-29 |
+| ESP32-S3 (ESP-IDF 5.5.2 / LX7)    | 550   | 2        | 2026-05-29 |
 
 > **float64 rows** used the `NUMX_USE_DOUBLE` build flag. Some Unity assertions
 > retain float32-level tolerances; affected tests still pass. See individual
 > result files for per-module detail.
+>
+> **ESP32-S3 2 failures** are in `numx_sketch_rsvd` (FLAG S-01): `rand()` seed portability
+> across libc implementations causes a degenerate random projection in one rank-2 test case.
+> The algorithm is correct — rank-1 and seed=0 cases pass with 0.00 error. See
+> `validation/results/sketch/sketch.md` for full analysis.
 
 ---
 


### PR DESCRIPTION
## What

Phase 2 ESP32-S3 validation was already complete (Amir Ab Khoshk), but the root README and validation README incorrectly stated 8/13 modules and 308 tests.

## Corrections

- **Root README** hardware table: `8 / 13 | 308 / 308` → `13 / 13 | 548 / 550`
- **Root README** note: removed "Phase 2 pending" — all 13 modules validated on ESP32-S3
- **validation/README.md** Unity summary: `308 / 0` → `550 / 2` with S-01 explanation

## The 2 failures (not a bug)

`numx_sketch_rsvd` rank-2 test fails on ESP32-S3 due to `rand()` producing a different sequence for the same seed under ESP-IDF vs glibc. The random projection matrix lands near the null space of the test matrix for that specific seed, returning near-zero singular values instead of {4, 2}. Rank-1 and seed=0 tests pass with 0.00 error. Full analysis in `validation/results/sketch/sketch.md` (FLAG S-01).