### PR TITLE
feat(validation): ARM64 Phase 2 results — M4 Pro / Apple clang 21.0.0

### DIFF
--- a/validation/README.md
+++ b/validation/README.md
@@ -101,7 +101,7 @@ validation/
 | Platform                           | Tests | Failures | Date       |
 |------------------------------------|-------|----------|------------|
 | x86-64 (Ubuntu 22.04 / gcc)        | 300   | 0        | 2026-05-25 |
-| ARM64 (macOS 26.2 / Apple clang)   | 300   | 0        | 2026-05-29 |
+| ARM64 (macOS 26.2 / Apple clang)   | 300   | 0        | 2026-06-08 |
 | Windows x64 (float32 / MSVC 14.51) | 295   | 0        | 2026-06-05 |
 | Windows x64 (float64 / MSVC 14.51) | 294   | 0        | 2026-06-06 |
 | ESP32-S3 (ESP-IDF 5.5.2 / LX7)    | 550   | 2        | 2026-05-29 |

--- a/validation/results/autodiff/autodiff.md
+++ b/validation/results/autodiff/autodiff.md
@@ -110,14 +110,59 @@ Covers: **forward-mode** (`numx_dual_t` — const, var, add, sub, mul, div, neg,
 
 ---
 
-## ARM64 — macOS / Apple M4 Pro / Apple clang / float32
-**Validator:** — | **Date:** — | **Commit:** —
+## ARM64 — macOS 26.2 / Apple M4 Pro / Apple clang 21.0.0 / float32
+**Validator:** Erfan Jazeb Nikoo | **Date:** 2026-06-08 | **Commit:** d81b386
 
 ### Test cases
 
-| Mode | Expression | Expected | Computed | Pass |
-|------|-----------|----------|----------|------|
-| *(awaiting results)* | | | | |
+| Test | Result |
+|------|--------|
+| test_dual_const | ✅ |
+| test_dual_var | ✅ |
+| test_dual_add | ✅ |
+| test_dual_sub | ✅ |
+| test_dual_mul | ✅ |
+| test_dual_div | ✅ |
+| test_dual_neg | ✅ |
+| test_dual_sin | ✅ |
+| test_dual_cos | ✅ |
+| test_dual_exp | ✅ |
+| test_dual_log | ✅ |
+| test_dual_sqrt | ✅ |
+| test_dual_chain_quadratic | ✅ |
+| test_dual_div_by_zero | ✅ |
+| test_dual_log_nonpositive | ✅ |
+| test_dual_sqrt_negative | ✅ |
+| test_ad_init | ✅ |
+| test_ad_var | ✅ |
+| test_ad_add_backward | ✅ |
+| test_ad_sub_backward | ✅ |
+| test_ad_mul_backward | ✅ |
+| test_ad_div_backward | ✅ |
+| test_ad_neg_backward | ✅ |
+| test_ad_sin_backward | ✅ |
+| test_ad_cos_backward | ✅ |
+| test_ad_exp_backward | ✅ |
+| test_ad_log_backward | ✅ |
+| test_ad_sqrt_backward | ✅ |
+| test_ad_quadratic | ✅ |
+| test_ad_null_returns_error | ✅ |
+| test_ad_invalid_idx_returns_error | ✅ |
+| test_ad_div_by_zero_returns_error | ✅ |
+| test_ad_log_nonpositive_returns_error | ✅ |
+| test_ad_sqrt_negative_returns_error | ✅ |
+
+*300 / 300 Unity tests PASS*
+
+### Performance
+
+| Operation | N | Total | Per call |
+|-----------|---|-------|----------|
+| dual fwd: mul-chain depth=10 | 100,000 | 8,632 µs | 86 ns |
+| tape: rev grad x²+y² | 10,000 | 21,134 µs | 2,113 ns |
+| tape: rev grad x²+y²+z² (3 vars) | 10,000 | 22,236 µs | 2,223 ns |
+
+**RESULTS: 34 PASS / 0 FAIL / 34 TOTAL**
 
 ---
 

--- a/validation/results/compressed_sensing/compressed_sensing.md
+++ b/validation/results/compressed_sensing/compressed_sensing.md
@@ -43,14 +43,40 @@ Covers: `numx_cs_spectral_norm` · `numx_cs_omp` (Orthogonal Matching Pursuit) �
 
 ---
 
-## ARM64 — macOS / Apple M4 Pro / Apple clang / float32
-**Validator:** — | **Date:** — | **Commit:** —
+## ARM64 — macOS 26.2 / Apple M4 Pro / Apple clang 21.0.0 / float32
+**Validator:** Erfan Jazeb Nikoo | **Date:** 2026-06-08 | **Commit:** d81b386
 
 ### Test cases
 
-| Function | Scenario | Expected | Computed | Pass |
-|----------|---------|----------|----------|------|
-| *(awaiting results)* | | | | |
+| Test | Result |
+|------|--------|
+| test_spectral_norm_identity | ✅ |
+| test_spectral_norm_scaled_identity | ✅ |
+| test_spectral_norm_tall_matrix | ✅ |
+| test_spectral_norm_null_returns_error | ✅ |
+| test_spectral_norm_invalid_arg | ✅ |
+| test_omp_identity_1sparse | ✅ |
+| test_omp_identity_2sparse | ✅ |
+| test_omp_overdetermined_1sparse | ✅ |
+| test_omp_null_returns_error | ✅ |
+| test_omp_invalid_arg_returns_error | ✅ |
+| test_ista_identity_shrinkage | ✅ |
+| test_ista_zero_lambda_recovery | ✅ |
+| test_ista_large_lambda_zeros | ✅ |
+| test_ista_null_returns_error | ✅ |
+| test_ista_invalid_step_returns_error | ✅ |
+
+*300 / 300 Unity tests PASS*
+
+### Performance
+
+| Function | N | Total | Per call |
+|----------|---|-------|----------|
+| cs_spectral_norm 16×32 iter=32 | 100 | 4,681 µs | 46,810 ns |
+| cs_omp 16×32 k=4 | 100 | 261 µs | 2,610 ns |
+| cs_ista 16×32 lam=0.1 iter=500 | 100 | 57,834 µs | 578,340 ns |
+
+**RESULTS: 15 PASS / 0 FAIL / 15 TOTAL**
 
 ---
 

--- a/validation/results/fft/fft.md
+++ b/validation/results/fft/fft.md
@@ -44,20 +44,46 @@ Covers: `fft_f32` · `ifft_f32` · `fft_q15` · `fft_magnitude`
 
 ---
 
-## ARM64 — macOS / Apple M4 Pro / Apple clang / float32
-**Validator:** — | **Date:** — | **Commit:** —
+## ARM64 — macOS 26.2 / Apple M4 Pro / Apple clang 21.0.0 / float32
+**Validator:** Erfan Jazeb Nikoo | **Date:** 2026-06-08 | **Commit:** d81b386
 
 ### Test cases
 
-| Function | Input / scenario | Expected | Computed | Error | Pass |
-|----------|-----------------|----------|----------|-------|------|
-| *(awaiting results)* | | | | | |
+| Test | Result |
+|------|--------|
+| test_fft_dc_n4 | ✅ |
+| test_fft_single_tone_n4 | ✅ |
+| test_fft_dc_n2 | ✅ |
+| test_fft_n1_passthrough | ✅ |
+| test_fft_delta_at_0 | ✅ |
+| test_fft_null_returns_error | ✅ |
+| test_fft_n_not_power_of_two | ✅ |
+| test_fft_n_exceeds_max | ✅ |
+| test_ifft_roundtrip | ✅ |
+| test_ifft_dc_spectrum | ✅ |
+| test_ifft_null_returns_error | ✅ |
+| test_fft_q15_dc_n4 | ✅ |
+| test_fft_q15_null_returns_error | ✅ |
+| test_fft_q15_n_not_power_of_two | ✅ |
+| test_fft_magnitude_dc | ✅ |
+| test_fft_magnitude_complex_bin | ✅ |
+| test_fft_magnitude_null_returns_error | ✅ |
+| test_fft_magnitude_n1_invalid | ✅ |
+
+*300 / 300 Unity tests PASS*
 
 ### Performance
 
 | Function | N | Total | Per call |
 |----------|---|-------|----------|
-| *(awaiting results)* | | | |
+| fft_f32 N=64 | 10,000 | 117,208 µs | 11,720 ns |
+| fft_f32 N=256 | 5,000 | 308,169 µs | 61,633 ns |
+| fft_f32 N=512 | 1,000 | 135,266 µs | 135,266 ns |
+| ifft_f32 N=256 | 5,000 | 319,544 µs | 63,908 ns |
+| fft_q15 N=256 | 5,000 | 315,945 µs | 63,189 ns |
+| fft_magnitude N=256 | 100,000 | 2,981,845 µs | 29,818 ns |
+
+**RESULTS: 18 PASS / 0 FAIL / 18 TOTAL**
 
 ---
 

--- a/validation/results/signal/signal.md
+++ b/validation/results/signal/signal.md
@@ -52,20 +52,55 @@ Covers: `window_rect` · `window_hann` · `window_hamming` · `window_blackman` 
 
 ---
 
-## ARM64 — macOS / Apple M4 Pro / Apple clang / float32
-**Validator:** — | **Date:** — | **Commit:** —
+## ARM64 — macOS 26.2 / Apple M4 Pro / Apple clang 21.0.0 / float32
+**Validator:** Erfan Jazeb Nikoo | **Date:** 2026-06-08 | **Commit:** d81b386
 
 ### Test cases
 
-| Function | Input / scenario | Expected | Computed | Error | Pass |
-|----------|-----------------|----------|----------|-------|------|
-| *(awaiting results)* | | | | | |
+| Test | Result |
+|------|--------|
+| test_window_rect_all_ones | ✅ |
+| test_window_rect_n1 | ✅ |
+| test_window_hann_endpoints_zero | ✅ |
+| test_window_hann_midpoint_one | ✅ |
+| test_window_hann_n1_returns_one | ✅ |
+| test_window_hamming_endpoints | ✅ |
+| test_window_hamming_midpoint_one | ✅ |
+| test_window_blackman_endpoints_zero | ✅ |
+| test_window_blackman_midpoint_one | ✅ |
+| test_convolve_box | ✅ |
+| test_convolve_unit_impulse | ✅ |
+| test_convolve_null_returns_error | ✅ |
+| test_correlate_autocorr_peak_at_lag0 | ✅ |
+| test_correlate_output_length | ✅ |
+| test_fir_identity_tap | ✅ |
+| test_fir_moving_average | ✅ |
+| test_fir_null_returns_error | ✅ |
+| test_iir_biquad_identity | ✅ |
+| test_iir_biquad_scale | ✅ |
+| test_iir_biquad_null_returns_error | ✅ |
+| test_peaks_two_peaks | ✅ |
+| test_peaks_monotone_no_peaks | ✅ |
+| test_peaks_short_signal_no_peaks | ✅ |
+| test_peaks_buffer_too_small | ✅ |
+| test_ema_alpha1_copies_input | ✅ |
+| test_ema_alpha0_stays_at_first | ✅ |
+| test_ema_known_sequence | ✅ |
+| test_ema_invalid_alpha_returns_error | ✅ |
+
+*300 / 300 Unity tests PASS*
 
 ### Performance
 
 | Function | N | Total | Per call |
 |----------|---|-------|----------|
-| *(awaiting results)* | | | |
+| signal_window_hann n=512 | 100,000 | 1,385,067 µs | 13,850 ns |
+| signal_convolve xn=256 hn=32 | 10,000 | 79,979 µs | 7,997 ns |
+| signal_fir xn=256 ntaps=32 | 10,000 | 87,555 µs | 8,755 ns |
+| signal_iir_biquad n=256 | 50,000 | 60,056 µs | 1,201 ns |
+| signal_ema n=256 alpha=0.1 | 50,000 | 19,235 µs | 384 ns |
+
+**RESULTS: 28 PASS / 0 FAIL / 28 TOTAL**
 
 ---
 

--- a/validation/results/sketch/sketch.md
+++ b/validation/results/sketch/sketch.md
@@ -35,14 +35,30 @@ Covers: `numx_sketch_rsvd` — Halko-Martinsson-Tropp randomized SVD
 
 ---
 
-## ARM64 — macOS / Apple M4 Pro / Apple clang / float32
-**Validator:** — | **Date:** — | **Commit:** —
+## ARM64 — macOS 26.2 / Apple M4 Pro / Apple clang 21.0.0 / float32
+**Validator:** Erfan Jazeb Nikoo | **Date:** 2026-06-08 | **Commit:** d81b386
 
 ### Test cases
 
-| A | rank | σ expected | σ computed | Error | Pass |
-|---|------|-----------|-----------|-------|------|
-| *(awaiting results)* | | | | | |
+| Test | Result |
+|------|--------|
+| test_rsvd_rank1_reconstruction | ✅ |
+| test_rsvd_diagonal_rank2 | ✅ |
+| test_rsvd_tall_matrix | ✅ |
+| test_rsvd_null_returns_error | ✅ |
+| test_rsvd_invalid_arg_returns_error | ✅ |
+
+*300 / 300 Unity tests PASS*
+
+### Performance
+
+| Function | N | Total | Per call |
+|----------|---|-------|----------|
+| sketch_rsvd 16×16 rank=4 os=4 | 100 | 45,036 µs | 450,360 ns |
+| sketch_rsvd 32×32 rank=8 os=4 | 100 | 113,795 µs | 1,137,950 ns |
+| sketch_rsvd 64×64 rank=8 os=4 | 100 | 138,754 µs | 1,387,540 ns |
+
+**RESULTS: 5 PASS / 0 FAIL / 5 TOTAL**
 
 ---
 


### PR DESCRIPTION
## Summary
- Fills in ARM64 (macOS 26.2 / Apple M4 Pro / Apple clang 21.0.0) validation sections for all 5 Phase 2 modules
- 300 / 300 Unity tests PASS across full suite (Phase 1 + Phase 2)
- Timing data from `val_bench_phase2` for signal, fft, autodiff, sketch, compressed_sensing
- Updates ARM64 Unity test summary date in `validation/README.md`

ARM64 Phase 2 is now fully documented. All platforms complete: x86-64 ✅ ARM64 ✅ Windows ✅ ESP32-S3 ✅