### PR TITLE
feat(validation): add M1 Pro ARM64 results — Phase 1 & 2

### DIFF
--- a/validation/README.md
+++ b/validation/README.md
@@ -1,9 +1,9 @@
 # numx Validation — Phase 1 & 2
 
-**numx commit:** d81b386 (x86-64 / ESP32-S3) / 0248577 (Apple Silicon) / 4c4c0f0 (Windows float32) / 1bba399 (Windows float64)
+**numx commit:** d81b386 (x86-64 / ESP32-S3) / 0248577 (M4 Pro) / 1380ab1 (M1 Pro) / 4c4c0f0 (Windows float32) / 1bba399 (Windows float64)
 **Validators:** Amir Ab Khoshk (x86-64, ESP32-S3, Windows), Erfan Jazeb Nikoo (Apple Silicon)
 **Validation start:** 2026-05-25
-**Status:** x86-64 complete ✅ | Apple Silicon complete ✅ | ESP32-S3 complete ✅ | Windows complete ✅
+**Status:** x86-64 complete ✅ | Apple Silicon (M4 Pro + M1 Pro) complete ✅ | ESP32-S3 complete ✅ | Windows complete ✅
 
 ---
 
@@ -14,7 +14,8 @@ validation/
 ├── README.md                  ← this file
 ├── hardware/
 │   ├── host_linux_x86_64.md   ← x86 host profile
-│   ├── mac_mini_m4_pro.md     ← Apple Silicon profile (macOS 26.2 / arm64)
+│   ├── mac_mini_m4_pro.md     ← Apple M4 Pro profile (macOS 26.2 / arm64)
+│   ├── mac_m1_pro.md          ← Apple M1 Pro profile (macOS 26.2 / arm64)
 │   ├── windows_msvc.md        ← Windows x64 profile (MSVC 14.51 / VS 2026 Build Tools)
 │   └── esp32_devkit_v1.md     ← ESP32-S3 profile (Phase 1 & 2 complete)
 ├── results/
@@ -98,13 +99,14 @@ validation/
 
 ## Unity test summary
 
-| Platform                           | Tests | Failures | Date       |
-|------------------------------------|-------|----------|------------|
-| x86-64 (Ubuntu 22.04 / gcc)        | 300   | 0        | 2026-05-25 |
-| ARM64 (macOS 26.2 / Apple clang)   | 300   | 0        | 2026-06-08 |
-| Windows x64 (float32 / MSVC 14.51) | 295   | 0        | 2026-06-05 |
-| Windows x64 (float64 / MSVC 14.51) | 294   | 0        | 2026-06-06 |
-| ESP32-S3 (ESP-IDF 5.5.2 / LX7)    | 550   | 2        | 2026-05-29 |
+| Platform                                                  | Tests | Failures | Date       |
+|-----------------------------------------------------------|-------|----------|------------|
+| x86-64 (Ubuntu 22.04 / gcc)                               | 300   | 0        | 2026-05-25 |
+| ARM64 (macOS 26.2 / Apple clang 21.0.0 / M4 Pro)         | 300   | 0        | 2026-06-08 |
+| ARM64 (macOS 26.2 / Apple clang 17.0.0 / M1 Pro)         | 300   | 0        | 2026-06-08 |
+| Windows x64 (float32 / MSVC 14.51)                        | 295   | 0        | 2026-06-05 |
+| Windows x64 (float64 / MSVC 14.51)                        | 294   | 0        | 2026-06-06 |
+| ESP32-S3 (ESP-IDF 5.5.2 / LX7)                           | 550   | 2        | 2026-05-29 |
 
 > **float64 rows** used the `NUMX_USE_DOUBLE` build flag. Some Unity assertions
 > retain float32-level tolerances; affected tests still pass. See individual

--- a/validation/hardware/mac_m1_pro.md
+++ b/validation/hardware/mac_m1_pro.md
@@ -1,0 +1,108 @@
+# Hardware Profile: MacBook Pro (Apple M1 Pro)
+
+**Profile date:** 2026-06-08
+**numx commit:** 1380ab1
+**Validator:** Erfan Jazeb Nikoo
+
+## System
+
+| Field        | Value                                              |
+|--------------|----------------------------------------------------|
+| Machine      | MacBook Pro (Model: MacBookPro18,3)                |
+| Chip         | Apple M1 Pro                                       |
+| Architecture | arm64 (AArch64)                                    |
+| CPU cores    | 10 (8 performance + 2 efficiency)                  |
+| Memory       | 16 GB                                              |
+| OS           | macOS 26.2 (Darwin 25.2.0)                         |
+| Compiler     | Apple clang 17.0.0 (clang-1700.6.3.2)              |
+| C standard   | C99 (`-std=c99`)                                   |
+| Optimisation | `-O2`                                              |
+| Precision    | float32 (`NUMX_USE_DOUBLE` not defined)            |
+| CMake        | 4.3.2                                              |
+
+## Notes
+
+- Apple M1 Pro is an earlier-generation Apple Silicon (2021) compared to M4 Pro.
+  Both use the same arm64 AArch64 ISA with hardware single-precision FPU.
+  IEEE 754 float32 results are bit-identical between M1 Pro and M4 Pro — confirms
+  deterministic behaviour across ARM64 microarchitecture generations.
+- Apple clang 17.0.0 (LLVM-based) vs clang 21.0.0 used on the M4 Pro host.
+  Different toolchain version; confirms library compiles cleanly across clang generations.
+- ARM64 is the closest available host ISA to embedded ARM Cortex-M targets;
+  results here are more predictive of Cortex-M behaviour than x86-64 results.
+- System rebooted to clean idle state before benchmarking. No other user sessions
+  or background processes active during timing runs.
+- cmake installed via pip3 (`/Users/erfan/Library/Python/3.9/bin/cmake`).
+
+## Test results
+
+**300 / 300 tests PASS. 0 failures.**
+
+```
+export PATH="$PATH:/Users/erfan/Library/Python/3.9/bin"
+cmake -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build --parallel
+./build/numx_tests
+```
+
+## Benchmark results
+
+Benchmarks run via dedicated validation runners (`val_runner` — Phase 1 and
+`val_bench_phase2` — Phase 2) on a clean rebooted system.
+
+### Phase 1 — core functions
+
+| Function | N | Total (µs) | Per call (ns) |
+|----------|---|------------|---------------|
+| vec_dot n=4 | 100,000 | 299 | 2 |
+| vec_norm L2 n=2 | 100,000 | 767 | 7 |
+| vec_cross3 | 100,000 | 131 | 1 |
+| mat_mul 2×2 | 100,000 | 660 | 6 |
+| mat_det 4×4 | 100,000 | 524 | 5 |
+| lu_decompose 4×4 | 100,000 | 8,359 | 83 |
+| stats_mean n=8 | 100,000 | 265 | 2 |
+| stats_variance_pop n=8 | 100,000 | 807 | 8 |
+| stats_median n=8 | 100,000 | 3,721 | 37 |
+| stats_percentile p50 n=8 | 100,000 | 2,090 | 20 |
+| root_bisect x²-2 | 10,000 | 1,083 | 108 |
+| root_newton x²-2 | 10,000 | 93 | 9 |
+| root_brent x²-2 | 10,000 | 706 | 70 |
+| integrate_trap n=100 | 50,000 | 5,595 | 111 |
+| integrate_simpson n=100 | 50,000 | 5,113 | 102 |
+| integrate_gauss npts=2 | 50,000 | 217 | 4 |
+| diff_forward | 100,000 | 360 | 3 |
+| diff_central | 100,000 | 370 | 3 |
+| diff_richardson | 100,000 | 404 | 4 |
+| interp_linear n=5 | 50,000 | 124 | 2 |
+| interp_spline_cubic n=5 (one-shot) | 50,000 | 836 | 16 |
+| interp_spline_eval n=5 (pre-built) | 50,000 | 172 | 3 |
+| interp_chebyshev n=8 | 50,000 | 5,942 | 118 |
+| poly_eval degree=3 | 100,000 | 329 | 3 |
+| poly_roots degree=3 | 1,000 | 78 | 78 |
+| rk4 decay n=1 100 steps | 10,000 | 33,639 | 3,363 |
+| rk45 decay tol=1e-4 | 10,000 | 4,703 | 470 |
+
+### Phase 2 — autodiff, FFT, signal, sketch, compressed sensing
+
+| Function | N | Total (µs) | Per call (ns) |
+|----------|---|------------|---------------|
+| dual fwd: mul-chain depth=10 | 100,000 | 821 | 8 |
+| tape: rev grad x²+y² | 10,000 | 6,675 | 667 |
+| tape: rev grad x²+y²+z² (3 vars) | 10,000 | 6,905 | 690 |
+| fft_f32 N=64 | 10,000 | 25,478 | 2,547 |
+| fft_f32 N=256 | 5,000 | 67,538 | 13,507 |
+| fft_f32 N=512 | 1,000 | 30,423 | 30,423 |
+| ifft_f32 N=256 | 5,000 | 67,353 | 13,470 |
+| fft_q15 N=256 | 5,000 | 64,906 | 12,981 |
+| fft_magnitude N=256 | 100,000 | 1,954,211 | 19,542 |
+| signal_window_hann n=512 | 100,000 | 383,955 | 3,839 |
+| signal_convolve xn=256 hn=32 | 10,000 | 23,107 | 2,310 |
+| signal_fir xn=256 ntaps=32 | 10,000 | 48,926 | 4,892 |
+| signal_iir_biquad n=256 | 50,000 | 38,541 | 770 |
+| signal_ema n=256 alpha=0.1 | 50,000 | 27,009 | 540 |
+| sketch_rsvd 16×16 rank=4 os=4 | 100 | 37,542 | 375,420 |
+| sketch_rsvd 32×32 rank=8 os=4 | 100 | 95,309 | 953,090 |
+| sketch_rsvd 64×64 rank=8 os=4 | 100 | 110,159 | 1,101,590 |
+| cs_spectral_norm 16×32 iter=32 | 100 | 2,191 | 21,910 |
+| cs_omp 16×32 k=4 | 100 | 117 | 1,170 |
+| cs_ista 16×32 lam=0.1 iter=500 | 100 | 16,765 | 167,650 |

--- a/validation/results/autodiff/autodiff.md
+++ b/validation/results/autodiff/autodiff.md
@@ -110,6 +110,62 @@ Covers: **forward-mode** (`numx_dual_t` — const, var, add, sub, mul, div, neg,
 
 ---
 
+## ARM64 — macOS 26.2 / Apple M1 Pro / Apple clang 17.0.0 / float32
+**Validator:** Erfan Jazeb Nikoo | **Date:** 2026-06-08 | **Commit:** 1380ab1
+
+### Test cases
+
+| Test | Result |
+|------|--------|
+| test_dual_const | ✅ |
+| test_dual_var | ✅ |
+| test_dual_add | ✅ |
+| test_dual_sub | ✅ |
+| test_dual_mul | ✅ |
+| test_dual_div | ✅ |
+| test_dual_neg | ✅ |
+| test_dual_sin | ✅ |
+| test_dual_cos | ✅ |
+| test_dual_exp | ✅ |
+| test_dual_log | ✅ |
+| test_dual_sqrt | ✅ |
+| test_dual_chain_quadratic | ✅ |
+| test_dual_div_by_zero | ✅ |
+| test_dual_log_nonpositive | ✅ |
+| test_dual_sqrt_negative | ✅ |
+| test_ad_init | ✅ |
+| test_ad_var | ✅ |
+| test_ad_add_backward | ✅ |
+| test_ad_sub_backward | ✅ |
+| test_ad_mul_backward | ✅ |
+| test_ad_div_backward | ✅ |
+| test_ad_neg_backward | ✅ |
+| test_ad_sin_backward | ✅ |
+| test_ad_cos_backward | ✅ |
+| test_ad_exp_backward | ✅ |
+| test_ad_log_backward | ✅ |
+| test_ad_sqrt_backward | ✅ |
+| test_ad_quadratic | ✅ |
+| test_ad_null_returns_error | ✅ |
+| test_ad_invalid_idx_returns_error | ✅ |
+| test_ad_div_by_zero_returns_error | ✅ |
+| test_ad_log_nonpositive_returns_error | ✅ |
+| test_ad_sqrt_negative_returns_error | ✅ |
+
+*300 / 300 Unity tests PASS*
+
+### Performance
+
+| Operation | N | Total | Per call |
+|-----------|---|-------|----------|
+| dual fwd: mul-chain depth=10 | 100,000 | 821 µs | 8 ns |
+| tape: rev grad x²+y² | 10,000 | 6,675 µs | 667 ns |
+| tape: rev grad x²+y²+z² (3 vars) | 10,000 | 6,905 µs | 690 ns |
+
+**RESULTS: 34 PASS / 0 FAIL / 34 TOTAL**
+
+---
+
 ## ARM64 — macOS 26.2 / Apple M4 Pro / Apple clang 21.0.0 / float32
 **Validator:** Erfan Jazeb Nikoo | **Date:** 2026-06-08 | **Commit:** d81b386
 

--- a/validation/results/compressed_sensing/compressed_sensing.md
+++ b/validation/results/compressed_sensing/compressed_sensing.md
@@ -80,6 +80,43 @@ Covers: `numx_cs_spectral_norm` · `numx_cs_omp` (Orthogonal Matching Pursuit) �
 
 ---
 
+## ARM64 — macOS 26.2 / Apple M1 Pro / Apple clang 17.0.0 / float32
+**Validator:** Erfan Jazeb Nikoo | **Date:** 2026-06-08 | **Commit:** 1380ab1
+
+### Test cases
+
+| Test | Result |
+|------|--------|
+| test_spectral_norm_identity | ✅ |
+| test_spectral_norm_scaled_identity | ✅ |
+| test_spectral_norm_tall_matrix | ✅ |
+| test_spectral_norm_null_returns_error | ✅ |
+| test_spectral_norm_invalid_arg | ✅ |
+| test_omp_identity_1sparse | ✅ |
+| test_omp_identity_2sparse | ✅ |
+| test_omp_overdetermined_1sparse | ✅ |
+| test_omp_null_returns_error | ✅ |
+| test_omp_invalid_arg_returns_error | ✅ |
+| test_ista_identity_shrinkage | ✅ |
+| test_ista_zero_lambda_recovery | ✅ |
+| test_ista_large_lambda_zeros | ✅ |
+| test_ista_null_returns_error | ✅ |
+| test_ista_invalid_step_returns_error | ✅ |
+
+*300 / 300 Unity tests PASS*
+
+### Performance
+
+| Function | N | Total | Per call |
+|----------|---|-------|----------|
+| cs_spectral_norm 16×32 iter=32 | 100 | 2,191 µs | 21,910 ns |
+| cs_omp 16×32 k=4 | 100 | 117 µs | 1,170 ns |
+| cs_ista 16×32 lam=0.1 iter=500 | 100 | 16,765 µs | 167,650 ns |
+
+**RESULTS: 15 PASS / 0 FAIL / 15 TOTAL**
+
+---
+
 ## ESP32-S3 — ESP-IDF v5.5.2 / Xtensa LX7 / xtensa-esp32s3-elf-gcc / float32
 **Validator:** Amir Ab Khoshk | **Date:** 2026-05-29 | **Commit:** d81b386
 

--- a/validation/results/differentiate/differentiate.md
+++ b/validation/results/differentiate/differentiate.md
@@ -222,3 +222,28 @@ Identical values to x86-64 — confirms float32 cancellation is deterministic ac
 | diff_richardson h=1e-3 | 100,000 | 558 µs | 5 ns |
 
 **RESULTS: 19 PASS / 0 FAIL / 19 TOTAL**
+
+---
+
+## ARM64 — macOS 26.2 / Apple M1 Pro / Apple clang 17.0.0 / float32
+**Validator:** Erfan Jazeb Nikoo | **Date:** 2026-06-08 | **Commit:** 1380ab1
+
+### Test cases (f(x)=x³ at x=2, exact f′=12.0, h=1e-4)
+
+| Function | Expected | Computed | Error | Pass |
+|----------|----------|----------|-------|------|
+| forward | 12.0 | 11.98768616 | 1.23e-02 | ✅ NOTE: float32 limit |
+| central | 12.0 | 11.99483871 | 5.16e-03 | ✅ NOTE: float32 limit |
+| richardson | 12.0 | 12.00437546 | 4.38e-03 | ✅ NOTE: float32 limit |
+
+Identical values to x86-64 and ARM64 M4 Pro — IEEE 754 float32 cancellation is deterministic across all ARM64 variants.
+
+*300 / 300 Unity tests PASS*
+
+### Performance
+
+| Function | N | Total | Per call |
+|----------|---|-------|----------|
+| diff_forward | 100,000 | 360 µs | 3 ns |
+| diff_central | 100,000 | 370 µs | 3 ns |
+| diff_richardson | 100,000 | 404 µs | 4 ns |

--- a/validation/results/fft/fft.md
+++ b/validation/results/fft/fft.md
@@ -274,3 +274,46 @@ Covers: `fft_f32` · `ifft_f32` · `fft_q15` · `fft_magnitude`
 | fft_magnitude N=256 | 100,000 | 3,139,824 µs | 31,398 ns |
 
 **RESULTS: 18 PASS / 0 FAIL / 18 TOTAL**
+
+---
+
+## ARM64 — macOS 26.2 / Apple M1 Pro / Apple clang 17.0.0 / float32
+**Validator:** Erfan Jazeb Nikoo | **Date:** 2026-06-08 | **Commit:** 1380ab1
+
+### Test cases
+
+| Test | Result |
+|------|--------|
+| test_fft_dc_n4 | ✅ |
+| test_fft_single_tone_n4 | ✅ |
+| test_fft_dc_n2 | ✅ |
+| test_fft_n1_passthrough | ✅ |
+| test_fft_delta_at_0 | ✅ |
+| test_fft_null_returns_error | ✅ |
+| test_fft_n_not_power_of_two | ✅ |
+| test_fft_n_exceeds_max | ✅ |
+| test_ifft_roundtrip | ✅ |
+| test_ifft_dc_spectrum | ✅ |
+| test_ifft_null_returns_error | ✅ |
+| test_fft_q15_dc_n4 | ✅ |
+| test_fft_q15_null_returns_error | ✅ |
+| test_fft_q15_n_not_power_of_two | ✅ |
+| test_fft_magnitude_dc | ✅ |
+| test_fft_magnitude_complex_bin | ✅ |
+| test_fft_magnitude_null_returns_error | ✅ |
+| test_fft_magnitude_n1_invalid | ✅ |
+
+*300 / 300 Unity tests PASS*
+
+### Performance
+
+| Function | N | Total | Per call |
+|----------|---|-------|----------|
+| fft_f32 N=64 | 10,000 | 25,478 µs | 2,547 ns |
+| fft_f32 N=256 | 5,000 | 67,538 µs | 13,507 ns |
+| fft_f32 N=512 | 1,000 | 30,423 µs | 30,423 ns |
+| ifft_f32 N=256 | 5,000 | 67,353 µs | 13,470 ns |
+| fft_q15 N=256 | 5,000 | 64,906 µs | 12,981 ns |
+| fft_magnitude N=256 | 100,000 | 1,954,211 µs | 19,542 ns |
+
+**RESULTS: 18 PASS / 0 FAIL / 18 TOTAL**

--- a/validation/results/integrate/integrate.md
+++ b/validation/results/integrate/integrate.md
@@ -253,3 +253,38 @@
 | integrate_gauss npts=8 | 50,000 | 783 µs | 15 ns |
 
 **RESULTS: 23 PASS / 0 FAIL / 23 TOTAL**
+
+---
+
+## ARM64 — macOS 26.2 / Apple M1 Pro / Apple clang 17.0.0 / float32
+**Validator:** Erfan Jazeb Nikoo | **Date:** 2026-06-08 | **Commit:** 1380ab1
+
+### Test cases
+
+| Function | Expected | Computed | Error | Pass |
+|----------|----------|----------|-------|------|
+| trap n=100 | 1.2500250 | 1.2500250340 | 0.00e+00 | ✅ NOTE: O(h²) |
+| trap n=1000 | 1.2500003 | 1.25000095 | 5.96e-07 | ✅ |
+| simpson n=100 | 1.25 | 1.25000012 | 1.19e-07 | ✅ |
+| gauss npts=2 | 1.25 | 1.25000000 | 0.00e+00 | ✅ |
+| gauss npts=4 | 1.25 | 1.25000000 | 0.00e+00 | ✅ |
+| gauss npts=8 | 1.25 | 1.25000000 | 0.00e+00 | ✅ |
+
+*300 / 300 Unity tests PASS*
+
+### Performance (f(x)=x³+1 on [0,1])
+
+| Function | n | N | Total | Per call |
+|----------|---|---|-------|----------|
+| integrate_trap | 100 | 50,000 | 5,595 µs | 111 ns |
+| integrate_simpson | 100 | 50,000 | 5,113 µs | 102 ns |
+| integrate_gauss npts=2 | — | 50,000 | 217 µs | 4 ns |
+
+### Precision vs numpy reference
+
+| Function | numpy | numx | Error |
+|----------|-------|------|-------|
+| trap n=100 | 1.2500250 | 1.2500250 | 0.00e+00 |
+| trap n=1000 | 1.2500003 | 1.25000095 | 5.96e-07 |
+| simpson n=100 | 1.2500000 | 1.25000012 | 1.19e-07 |
+| gauss npts=2,4,8 | 1.2500000 | 1.25000000 | 0.00e+00 |

--- a/validation/results/interpolate/interpolate.md
+++ b/validation/results/interpolate/interpolate.md
@@ -255,3 +255,39 @@
 | interp_chebyshev n=16 | 10,000 | 17,814 µs | 1,781 ns |
 
 **RESULTS: 24 PASS / 0 FAIL / 24 TOTAL**
+
+---
+
+## ARM64 — macOS 26.2 / Apple M1 Pro / Apple clang 17.0.0 / float32
+**Validator:** Erfan Jazeb Nikoo | **Date:** 2026-06-08 | **Commit:** 1380ab1
+
+### Test cases (nodes: xs=[0,1,2,3,4], ys=[0,1,4,9,16])
+
+| Function | Input | Expected | Computed | Error | Pass |
+|----------|-------|----------|----------|-------|------|
+| linear | x=1.5 | 2.5 | 2.50000000 | 0.00e+00 | ✅ |
+| linear | x=2.5 | 6.5 | 6.50000000 | 0.00e+00 | ✅ |
+| spline_cubic | x=1.5 | 2.23214293 | 2.23214293 | 0.00e+00 | ✅ |
+| spline_cubic | x=2.5 | 6.23214293 | 6.23214293 | 0.00e+00 | ✅ |
+| chebyshev n=8 | x=1.5 | 2.25 | 2.25000024 | 2.38e-07 | ✅ |
+| chebyshev n=16 | x=1.5 | 2.25 | 2.25000000 | 0.00e+00 | ✅ |
+
+*300 / 300 Unity tests PASS*
+
+### Performance
+
+| Function | n | N | Total | Per call |
+|----------|---|---|-------|----------|
+| interp_linear | 5 | 50,000 | 124 µs | 2 ns |
+| interp_spline_cubic (one-shot) | 5 | 50,000 | 836 µs | 16 ns |
+| interp_spline_eval (pre-built) | 5 | 50,000 | 172 µs | 3 ns |
+| interp_chebyshev n=8 | 8 | 50,000 | 5,942 µs | 118 ns |
+
+### Precision vs numpy reference
+
+| Function | ref | numx | Error |
+|----------|-----|------|-------|
+| linear x=1.5 | 2.5 | 2.50000000 | 0.00e+00 |
+| spline x=1.5 | 2.23214293 | 2.23214293 | 0.00e+00 |
+| spline x=2.5 | 6.23214293 | 6.23214293 | 0.00e+00 |
+| chebyshev n=8 x=1.5 | 2.25 | 2.25000024 | 2.38e-07 |

--- a/validation/results/linalg/lu_solve.md
+++ b/validation/results/linalg/lu_solve.md
@@ -162,3 +162,34 @@
 | lu_solve 4x4 (factored) | 100,000 | 4,310 µs | 43 ns |
 
 **RESULTS: 8 PASS / 0 FAIL / 8 TOTAL**
+
+---
+
+## ARM64 — macOS 26.2 / Apple M1 Pro / Apple clang 17.0.0 / float32
+**Validator:** Erfan Jazeb Nikoo | **Date:** 2026-06-08 | **Commit:** 1380ab1
+
+### Test cases (A·x = b, 4×4 system)
+
+| Component | Expected | Computed | Error | Pass |
+|-----------|----------|----------|-------|------|
+| x[0] | 1.0 | 1.00000000 | 0.00e+00 | ✅ |
+| x[1] | 0.0 | 0.00000000 | 0.00e+00 | ✅ |
+| x[2] | -1.0 | -1.00000000 | 0.00e+00 | ✅ |
+| x[3] | 1.0 | 1.00000000 | 0.00e+00 | ✅ |
+
+*300 / 300 Unity tests PASS*
+
+### Performance
+
+| Function | N | Total | Per call |
+|----------|---|-------|----------|
+| lu_decompose 4×4 (combined with lu_solve) | 100,000 | 8,359 µs | 83 ns |
+
+### Precision vs numpy reference
+
+| Component | numpy | numx | Error |
+|-----------|-------|------|-------|
+| x[0] | 1.0 | 1.00000000 | 0.00e+00 |
+| x[1] | 0.0 | 0.00000000 | 0.00e+00 |
+| x[2] | -1.0 | -1.00000000 | 0.00e+00 |
+| x[3] | 1.0 | 1.00000000 | 0.00e+00 |

--- a/validation/results/linalg/mat_det.md
+++ b/validation/results/linalg/mat_det.md
@@ -141,3 +141,33 @@
 | mat_det 4x4 | 100,000 | 6,224 µs | 62 ns |
 
 **RESULTS: 7 PASS / 0 FAIL / 7 TOTAL**
+
+---
+
+## ARM64 — macOS 26.2 / Apple M1 Pro / Apple clang 17.0.0 / float32
+**Validator:** Erfan Jazeb Nikoo | **Date:** 2026-06-08 | **Commit:** 1380ab1
+
+### Test cases
+
+| n | Expected | Computed | Error | Pass |
+|---|----------|----------|-------|------|
+| 1×1 [[5]] | 5.0 | 5.00000000 | 0.00e+00 | ✅ |
+| 2×2 [[1,2],[3,4]] | -2.0 | -2.00000000 | 0.00e+00 | ✅ |
+| 3×3 textbook | 4.0 | 4.00000000 | 0.00e+00 | ✅ |
+| 4×4 symmetric | 20.0 | 20.00000000 | 0.00e+00 | ✅ |
+
+*300 / 300 Unity tests PASS*
+
+### Performance
+
+| Size | N | Total | Per call |
+|------|---|-------|----------|
+| 4×4 | 100,000 | 524 µs | 5 ns |
+
+### Precision vs numpy reference
+
+| n | numpy | numx | Error |
+|---|-------|------|-------|
+| 2 | -2.0 | -2.00000000 | 0.00e+00 |
+| 3 | 4.0 | 4.00000000 | 0.00e+00 |
+| 4 | 20.0 | 20.00000000 | 0.00e+00 |

--- a/validation/results/linalg/mat_mul.md
+++ b/validation/results/linalg/mat_mul.md
@@ -146,3 +146,29 @@
 | mat_mul 8x8 | 10,000 | 7,878 µs | 787 ns |
 
 **RESULTS: 5 PASS / 0 FAIL / 5 TOTAL**
+
+---
+
+## ARM64 — macOS 26.2 / Apple M1 Pro / Apple clang 17.0.0 / float32
+**Validator:** Erfan Jazeb Nikoo | **Date:** 2026-06-08 | **Commit:** 1380ab1
+
+### Test cases
+
+| Case | Expected | Computed | Pass |
+|------|----------|----------|------|
+| 2×2 A@B | [19,22,43,50] | [19.000000, 22.000000, 43.000000, 50.000000] | ✅ |
+| 2×3 @ 3×2 | [58,64,139,154] | [58.000000, 64.000000, 139.000000, 154.000000] | ✅ |
+
+*300 / 300 Unity tests PASS*
+
+### Performance
+
+| Size | N | Total | Per call |
+|------|---|-------|----------|
+| 2×2 | 100,000 | 660 µs | 6 ns |
+
+### Precision vs numpy reference
+
+| Case | numpy | numx | Error |
+|------|-------|------|-------|
+| 2×2 all elements | exact integers | exact match | 0.00e+00 |

--- a/validation/results/linalg/mat_transpose.md
+++ b/validation/results/linalg/mat_transpose.md
@@ -98,3 +98,27 @@ Expected Sᵀ (in-place): [1,3,2,4]
 | mat_transpose_sq 8x8 | 100,000 | 7,026 µs | 70 ns |
 
 **RESULTS: 6 PASS / 0 FAIL / 6 TOTAL**
+
+---
+
+## ARM64 — macOS 26.2 / Apple M1 Pro / Apple clang 17.0.0 / float32
+**Validator:** Erfan Jazeb Nikoo | **Date:** 2026-06-08 | **Commit:** 1380ab1
+
+### Test cases
+
+| Test | Result |
+|------|--------|
+| test_mat_transpose_2x3 | ✅ |
+| test_mat_transpose_double_is_identity | ✅ |
+| test_mat_transpose_sq_inplace | ✅ |
+| test_mat_transpose_sq_twice_is_identity | ✅ |
+| test_mat_transpose_null | ✅ |
+| test_mat_transpose_sq_null | ✅ |
+
+*300 / 300 Unity tests PASS*
+
+### Performance
+
+*mat_transpose was not included in Phase 1 val_runner benchmark suite for this run.*
+
+**RESULTS: 6 PASS / 0 FAIL / 6 TOTAL**

--- a/validation/results/linalg/vec_cross3.md
+++ b/validation/results/linalg/vec_cross3.md
@@ -141,3 +141,31 @@
 | vec_cross3 | 100,000 | 507 µs | 5 ns |
 
 **RESULTS: 5 PASS / 0 FAIL / 5 TOTAL**
+
+---
+
+## ARM64 — macOS 26.2 / Apple M1 Pro / Apple clang 17.0.0 / float32
+**Validator:** Erfan Jazeb Nikoo | **Date:** 2026-06-08 | **Commit:** 1380ab1
+
+### Test cases
+
+| Input | Expected | Computed | Pass |
+|-------|----------|----------|------|
+| [1,0,0]×[0,1,0] | [0,0,1] | [0.000000, 0.000000, 1.000000] | ✅ |
+| [1,2,3]×[4,5,6] | [-3,6,-3] | [-3.000000, 6.000000, -3.000000] | ✅ |
+
+*300 / 300 Unity tests PASS*
+
+### Performance
+
+| N | Total | Per call |
+|---|-------|----------|
+| 100,000 | 131 µs | 1 ns |
+
+### Precision vs numpy reference
+
+| Input | component | numpy | numx | Error |
+|-------|-----------|-------|------|-------|
+| [1,2,3]×[4,5,6] | [0] | -3.0 | -3.0 | 0.00e+00 |
+| [1,2,3]×[4,5,6] | [1] | 6.0 | 6.0 | 0.00e+00 |
+| [1,2,3]×[4,5,6] | [2] | -3.0 | -3.0 | 0.00e+00 |

--- a/validation/results/linalg/vec_dot.md
+++ b/validation/results/linalg/vec_dot.md
@@ -145,3 +145,30 @@
 | vec_dot n=64 | 100,000 | 9,441 µs | 94 ns |
 
 **RESULTS: 10 PASS / 0 FAIL / 10 TOTAL**
+
+---
+
+## ARM64 — macOS 26.2 / Apple M1 Pro / Apple clang 17.0.0 / float32
+**Validator:** Erfan Jazeb Nikoo | **Date:** 2026-06-08 | **Commit:** 1380ab1
+
+### Test cases
+
+| Input | Expected | Computed | Error | Pass |
+|-------|----------|----------|-------|------|
+| [1,2,3,4]·[5,6,7,8] | 70.0 | 70.00000000 | 0.00e+00 | ✅ |
+| [1,0,0]·[0,1,0] (orthogonal) | 0.0 | 0.00000000 | 0.00e+00 | ✅ |
+
+*300 / 300 Unity tests PASS*
+
+### Performance
+
+| N | Total | Per call |
+|---|-------|----------|
+| 100,000 | 299 µs | 2 ns |
+
+### Precision vs numpy reference
+
+| Input | numpy (float32) | numx | Error |
+|-------|----------------|------|-------|
+| [1,2,3,4]·[5,6,7,8] | 70.0 | 70.00000000 | 0.00e+00 |
+| [1,0,0]·[0,1,0] | 0.0 | 0.00000000 | 0.00e+00 |

--- a/validation/results/linalg/vec_norm.md
+++ b/validation/results/linalg/vec_norm.md
@@ -148,3 +148,33 @@
 | vec_norm L1 n=64 | 100,000 | 10,408 µs | 104 ns |
 
 **RESULTS: 8 PASS / 0 FAIL / 8 TOTAL**
+
+---
+
+## ARM64 — macOS 26.2 / Apple M1 Pro / Apple clang 17.0.0 / float32
+**Validator:** Erfan Jazeb Nikoo | **Date:** 2026-06-08 | **Commit:** 1380ab1
+
+### Test cases
+
+| Input | Norm | Expected | Computed | Error | Pass |
+|-------|------|----------|----------|-------|------|
+| [3,4] | L2 | 5.0 | 5.00000000 | 0.00e+00 | ✅ |
+| [3,4] | L1 | 7.0 | 7.00000000 | 0.00e+00 | ✅ |
+| [3,4] | Linf | 4.0 | 4.00000000 | 0.00e+00 | ✅ |
+| [1,2,3,4,5] | L2 | sqrt(55)=7.41619849 | 7.41619873 | 4.77e-07 | ✅ |
+
+*300 / 300 Unity tests PASS*
+
+### Performance
+
+| Variant | N | Total | Per call |
+|---------|---|-------|----------|
+| L2 n=2 | 100,000 | 767 µs | 7 ns |
+
+### Precision vs numpy reference
+
+| Input | Norm | numpy | numx | Error |
+|-------|------|-------|------|-------|
+| [3,4] | L2 | 5.0 | 5.00000000 | 0.00e+00 |
+| [3,4] | L1 | 7.0 | 7.00000000 | 0.00e+00 |
+| [3,4] | Linf | 4.0 | 4.00000000 | 0.00e+00 |

--- a/validation/results/ode/ode.md
+++ b/validation/results/ode/ode.md
@@ -222,3 +222,39 @@
 | ode_rk45 harmonic n=2 tol=1e-4 | 1,000 | 450 µs | 450 ns |
 
 **RESULTS: 18 PASS / 0 FAIL / 18 TOTAL**
+
+---
+
+## ARM64 — macOS 26.2 / Apple M1 Pro / Apple clang 17.0.0 / float32
+**Validator:** Erfan Jazeb Nikoo | **Date:** 2026-06-08 | **Commit:** 1380ab1
+
+### Test cases
+
+| Function | Problem | Expected | Computed | Error | Pass |
+|----------|---------|----------|----------|-------|------|
+| rk4 | decay y(1.0) → e^-1 | 0.36787945 | 0.36787960 | 1.49e-07 | ✅ |
+| rk4 | harmonic x(1.0) → cos(1) | 0.54030234 | 0.54030234 | 0.00e+00 | ✅ |
+| rk4 | harmonic v(1.0) → -sin(1) | -0.84147096 | -0.84147084 | 1.19e-07 | ✅ |
+| rk4 | energy at t=1 | 0.5 | 0.4999999106 | 8.94e-08 | ✅ |
+| rk45 | decay y(1.0) tol=1e-4 | 0.36787945 | 0.36787939 | 5.96e-08 | ✅ |
+| rk45 | harmonic x(1.0) | 0.54030234 | 0.54030228 | 5.96e-08 | ✅ |
+| rk45 | harmonic energy | 0.5 | 0.5000000596 | 5.96e-08 | ✅ |
+
+*300 / 300 Unity tests PASS*
+
+### Performance
+
+| Function | N | Total | Per call |
+|----------|---|-------|----------|
+| rk4 decay (n=1, 100 steps) | 10,000 | 33,639 µs | 3,363 ns |
+| rk45 decay tol=1e-4 | 10,000 | 4,703 µs | 470 ns |
+
+### Precision vs reference (double)
+
+| Function | exact (double) | numx (float32) | Error |
+|----------|---------------|----------------|-------|
+| rk4 y(1.0) decay | 0.367879441171 | 0.36787960 | 1.49e-07 |
+| rk4 x(1.0) harmonic | 0.540302305868 | 0.54030234 | 0.00e+00 |
+| rk4 v(1.0) harmonic | -0.841470984808 | -0.84147084 | 1.19e-07 |
+| rk4 energy | 0.5 | 0.4999999106 | 8.94e-08 |
+| rk45 y(1.0) | 0.367879441171 | 0.36787939 | 5.96e-08 |

--- a/validation/results/poly/poly.md
+++ b/validation/results/poly/poly.md
@@ -214,3 +214,39 @@
 | poly_roots degree=3 tol=1e-4 | 1,000 | 205 µs | 205 ns |
 
 **RESULTS: 16 PASS / 0 FAIL / 16 TOTAL**
+
+---
+
+## ARM64 — macOS 26.2 / Apple M1 Pro / Apple clang 17.0.0 / float32
+**Validator:** Erfan Jazeb Nikoo | **Date:** 2026-06-08 | **Commit:** 1380ab1
+
+### Test cases
+
+| Function | Input | Expected | Computed | Error | Pass |
+|----------|-------|----------|----------|-------|------|
+| poly_eval | x=1 | 0.0 | 0.00000000 | 0.00e+00 | ✅ |
+| poly_eval | x=2 | 0.0 | 0.00000000 | 0.00e+00 | ✅ |
+| poly_eval | x=3 | 0.0 | 0.00000000 | 0.00e+00 | ✅ |
+| poly_eval | x=2.5 | -0.375 | -0.37500000 | 0.00e+00 | ✅ |
+| poly_eval | x=0 | -6.0 | -6.00000000 | 0.00e+00 | ✅ |
+| poly_eval degree-8 | x=1.5 | 12.44140625 | 12.44140625 | 0.00e+00 | ✅ |
+| poly_roots | [1,2,3] | r[0]=1.0 | 0.99999976 | 2.38e-07 | ✅ |
+| poly_roots | [1,2,3] | r[1]=2.0 | 2.00000119 | 1.19e-06 | ✅ |
+| poly_roots | [1,2,3] | r[2]=3.0 | 2.99999881 | 1.19e-06 | ✅ |
+
+*300 / 300 Unity tests PASS*
+
+### Performance
+
+| Function | degree | N | Total | Per call |
+|----------|--------|---|-------|----------|
+| poly_eval | 3 | 100,000 | 329 µs | 3 ns |
+| poly_roots | 3 | 1,000 | 78 µs | 78 ns |
+
+### Precision vs numpy reference
+
+| x | numpy | numx | Error |
+|---|-------|------|-------|
+| 1.0 | 0.0 | 0.00000000 | 0.00e+00 |
+| 2.5 | -0.375 | -0.37500000 | 0.00e+00 |
+| p8(1.5) | 12.44140625 | 12.44140625 | 0.00e+00 |

--- a/validation/results/roots/roots.md
+++ b/validation/results/roots/roots.md
@@ -232,3 +232,36 @@
 | root_brent x^3-x tol=1e-5 | 10,000 | 1,159 µs | 115 ns |
 
 **RESULTS: 25 PASS / 0 FAIL / 25 TOTAL**
+
+---
+
+## ARM64 — macOS 26.2 / Apple M1 Pro / Apple clang 17.0.0 / float32
+**Validator:** Erfan Jazeb Nikoo | **Date:** 2026-06-08 | **Commit:** 1380ab1
+
+### Test cases
+
+| Function | Expected | Computed | Error | Pass |
+|----------|----------|----------|-------|------|
+| bisect x²-2 on [1,2] | sqrt(2)=1.41421354 | 1.41421413 | 5.96e-07 | ✅ |
+| newton x²-2 x0=1.5 | sqrt(2)=1.41421354 | 1.41421354 | 0.00e+00 | ✅ |
+| brent x²-2 on [1,2] | sqrt(2)=1.41421354 | 1.41421354 | 0.00e+00 | ✅ |
+| brent x³-x-2 on [1,2] | 1.52137971 | 1.52137971 | 0.00e+00 | ✅ |
+
+*300 / 300 Unity tests PASS*
+
+### Performance
+
+| Function | tol | N | Total | Per call |
+|----------|-----|---|-------|----------|
+| root_bisect x²-2 | 1e-6 | 10,000 | 1,083 µs | 108 ns |
+| root_newton x²-2 | 1e-6 | 10,000 | 93 µs | 9 ns |
+| root_brent x²-2 | 1e-6 | 10,000 | 706 µs | 70 ns |
+
+### Precision vs reference (double)
+
+| Function | double ref | numx (float32) | Error |
+|----------|-----------|----------------|-------|
+| bisect x²-2 | 1.41421356 | 1.41421413 | 5.96e-07 |
+| newton x²-2 | 1.41421356 | 1.41421354 | 0.00e+00 |
+| brent x²-2 | 1.41421356 | 1.41421354 | 0.00e+00 |
+| brent x³-x-2 | 1.52137971 | 1.52137971 | 0.00e+00 |

--- a/validation/results/signal/signal.md
+++ b/validation/results/signal/signal.md
@@ -375,3 +375,55 @@ Covers: `window_rect` · `window_hann` · `window_hamming` · `window_blackman` 
 | signal_ema n=128 alpha=0.1 | 50,000 | 15,187 µs | 303 ns |
 
 **RESULTS: 28 PASS / 0 FAIL / 28 TOTAL**
+
+---
+
+## ARM64 — macOS 26.2 / Apple M1 Pro / Apple clang 17.0.0 / float32
+**Validator:** Erfan Jazeb Nikoo | **Date:** 2026-06-08 | **Commit:** 1380ab1
+
+### Test cases
+
+| Test | Result |
+|------|--------|
+| test_window_rect_all_ones | ✅ |
+| test_window_rect_n1 | ✅ |
+| test_window_hann_endpoints_zero | ✅ |
+| test_window_hann_midpoint_one | ✅ |
+| test_window_hann_n1_returns_one | ✅ |
+| test_window_hamming_endpoints | ✅ |
+| test_window_hamming_midpoint_one | ✅ |
+| test_window_blackman_endpoints_zero | ✅ |
+| test_window_blackman_midpoint_one | ✅ |
+| test_convolve_box | ✅ |
+| test_convolve_unit_impulse | ✅ |
+| test_convolve_null_returns_error | ✅ |
+| test_correlate_autocorr_peak_at_lag0 | ✅ |
+| test_correlate_output_length | ✅ |
+| test_fir_identity_tap | ✅ |
+| test_fir_moving_average | ✅ |
+| test_fir_null_returns_error | ✅ |
+| test_iir_biquad_identity | ✅ |
+| test_iir_biquad_scale | ✅ |
+| test_iir_biquad_null_returns_error | ✅ |
+| test_peaks_two_peaks | ✅ |
+| test_peaks_monotone_no_peaks | ✅ |
+| test_peaks_short_signal_no_peaks | ✅ |
+| test_peaks_buffer_too_small | ✅ |
+| test_ema_alpha1_copies_input | ✅ |
+| test_ema_alpha0_stays_at_first | ✅ |
+| test_ema_known_sequence | ✅ |
+| test_ema_invalid_alpha_returns_error | ✅ |
+
+*300 / 300 Unity tests PASS*
+
+### Performance
+
+| Function | N | Total | Per call |
+|----------|---|-------|----------|
+| signal_window_hann n=512 | 100,000 | 383,955 µs | 3,839 ns |
+| signal_convolve xn=256 hn=32 | 10,000 | 23,107 µs | 2,310 ns |
+| signal_fir xn=256 ntaps=32 | 10,000 | 48,926 µs | 4,892 ns |
+| signal_iir_biquad n=256 | 50,000 | 38,541 µs | 770 ns |
+| signal_ema n=256 alpha=0.1 | 50,000 | 27,009 µs | 540 ns |
+
+**RESULTS: 28 PASS / 0 FAIL / 28 TOTAL**

--- a/validation/results/sketch/sketch.md
+++ b/validation/results/sketch/sketch.md
@@ -62,6 +62,33 @@ Covers: `numx_sketch_rsvd` — Halko-Martinsson-Tropp randomized SVD
 
 ---
 
+## ARM64 — macOS 26.2 / Apple M1 Pro / Apple clang 17.0.0 / float32
+**Validator:** Erfan Jazeb Nikoo | **Date:** 2026-06-08 | **Commit:** 1380ab1
+
+### Test cases
+
+| Test | Result |
+|------|--------|
+| test_rsvd_rank1_reconstruction | ✅ |
+| test_rsvd_diagonal_rank2 | ✅ |
+| test_rsvd_tall_matrix | ✅ |
+| test_rsvd_null_returns_error | ✅ |
+| test_rsvd_invalid_arg_returns_error | ✅ |
+
+*300 / 300 Unity tests PASS*
+
+### Performance
+
+| Function | N | Total | Per call |
+|----------|---|-------|----------|
+| sketch_rsvd 16×16 rank=4 os=4 | 100 | 37,542 µs | 375,420 ns |
+| sketch_rsvd 32×32 rank=8 os=4 | 100 | 95,309 µs | 953,090 ns |
+| sketch_rsvd 64×64 rank=8 os=4 | 100 | 110,159 µs | 1,101,590 ns |
+
+**RESULTS: 5 PASS / 0 FAIL / 5 TOTAL**
+
+---
+
 ## ESP32-S3 — ESP-IDF v5.5.2 / Xtensa LX7 / xtensa-esp32s3-elf-gcc / float32
 **Validator:** Amir Ab Khoshk | **Date:** 2026-05-29 | **Commit:** d81b386
 

--- a/validation/results/stats/stats.md
+++ b/validation/results/stats/stats.md
@@ -253,3 +253,42 @@
 | stats_percentile p95 n=128 | 10,000 | 13,707 µs | 1,370 ns |
 
 **RESULTS: 26 PASS / 0 FAIL / 26 TOTAL**
+
+---
+
+## ARM64 — macOS 26.2 / Apple M1 Pro / Apple clang 17.0.0 / float32
+**Validator:** Erfan Jazeb Nikoo | **Date:** 2026-06-08 | **Commit:** 1380ab1
+
+### Test cases — dataset [2, 4, 4, 4, 5, 5, 7, 9]
+
+| Function | Expected | Computed | Error | Pass |
+|----------|----------|----------|-------|------|
+| mean | 5.0 | 5.00000000 | 0.00e+00 | ✅ |
+| variance (population) | 4.0 | 4.00000000 | 0.00e+00 | ✅ |
+| variance (sample) | 4.571429 | 4.57142878 | 0.00e+00 | ✅ |
+| median | 4.5 | 4.50000000 | 0.00e+00 | ✅ |
+| percentile p0 | 2.0 | 2.00000000 | 0.00e+00 | ✅ |
+| percentile p25 | 4.0 | 4.00000000 | 0.00e+00 | ✅ |
+| percentile p50 | 5.0 | 5.00000000 | 0.00e+00 | ✅ |
+| percentile p75 | 7.0 | 7.00000000 | 0.00e+00 | ✅ |
+| percentile p100 | 9.0 | 9.00000000 | 0.00e+00 | ✅ |
+
+*300 / 300 Unity tests PASS*
+
+### Performance (n=8 validation dataset)
+
+| Function | N | Total | Per call |
+|----------|---|-------|----------|
+| stats_mean n=8 | 100,000 | 265 µs | 2 ns |
+| stats_variance (pop) n=8 | 100,000 | 807 µs | 8 ns |
+| stats_median n=8 | 100,000 | 3,721 µs | 37 ns |
+| stats_percentile p50 n=8 | 100,000 | 2,090 µs | 20 ns |
+
+### Precision vs numpy reference
+
+| Function | numpy | numx | Error |
+|----------|-------|------|-------|
+| mean | 5.0 | 5.00000000 | 0.00e+00 |
+| variance pop | 4.0 | 4.00000000 | 0.00e+00 |
+| variance samp | 4.5714286 | 4.57142878 | 0.00e+00 |
+| median | 4.5 | 4.50000000 | 0.00e+00 |


### PR DESCRIPTION
## Summary
- M1 Pro (macOS 26.2 / Apple clang 17.0.0): 300/300 PASS across all 13 modules
- Adds hardware profile `validation/hardware/mac_m1_pro.md`
- Adds M1 Pro sections to all Phase 1 (8 modules) and Phase 2 (5 modules) result files
- S-01 (sketch rand() portability) does not affect Apple clang 17.0.0 — all rsvd tests pass

**Full platform coverage complete:**
| Platform | Tests | Pass |
|----------|-------|------|
| x86-64 Ubuntu / gcc | 300 | 300 |
| ARM64 M4 Pro / clang 21 | 300 | 300 |
| ARM64 M1 Pro / clang 17 | 300 | 300 |
| Windows x64 float32 / MSVC | 295 | 295 |
| Windows x64 float64 / MSVC | 294 | 294 |
| ESP32-S3 / Xtensa LX7 | 550 | 548 |