### PR TITLE
Add test cods

### DIFF
--- a/tests/bench_win.c
+++ b/tests/bench_win.c
@@ -1,0 +1,385 @@
+/**
+ * @file bench_win.c
+ * @brief Windows performance benchmarks — all 13 numx modules.
+ *        Works for both float32 (x86 build) and float64 (x64 build).
+ *        Uses QueryPerformanceCounter for sub-microsecond resolution.
+ */
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <stdio.h>
+#include <string.h>
+#include <math.h>
+
+#include "numx/linalg.h"
+#include "numx/stats.h"
+#include "numx/roots.h"
+#include "numx/integrate.h"
+#include "numx/differentiate.h"
+#include "numx/interpolate.h"
+#include "numx/poly.h"
+#include "numx/ode.h"
+#include "numx/autodiff.h"
+#include "numx/fft.h"
+#include "numx/signal.h"
+#include "numx/sketch.h"
+#include "numx/compressed_sensing.h"
+
+/* ── timing ─────────────────────────────────────────────────────────── */
+
+static LARGE_INTEGER s_freq;
+
+static void bench_init(void)
+{
+    QueryPerformanceFrequency(&s_freq);
+}
+
+static int64_t now_us(void)
+{
+    LARGE_INTEGER t;
+    QueryPerformanceCounter(&t);
+    return (int64_t)(t.QuadPart * 1000000LL / s_freq.QuadPart);
+}
+
+/* ── output ──────────────────────────────────────────────────────────── */
+
+static void bprint(const char *lbl, int64_t us, int n)
+{
+    int64_t ns = (us * 1000LL) / n;
+    printf("| %-44s | %6d | %8lld us | %7lld ns |\n",
+           lbl, n, (long long)us, (long long)ns);
+}
+
+static void bench_section(const char *target_md)
+{
+    printf("\n  >>> results/%s\n", target_md);
+    printf("  | %-44s | N      | Total us | ns/call  |\n", "Function");
+    printf("  |%-46s|--------|----------|----------|\n",
+           "----------------------------------------------");
+}
+
+#define BENCH(lbl, n, body) do { \
+    int64_t _t0 = now_us(); \
+    for (int _i = 0; _i < (n); _i++) { body; } \
+    int64_t _t1 = now_us(); \
+    printf("  "); bprint((lbl), _t1 - _t0, (n)); \
+} while (0)
+
+/* ── math helpers (match ESP32 bench / test helpers) ─────────────────── */
+
+static numx_real_t f_quad(numx_real_t x)  { return x * x - (numx_real_t)4.0; }
+static numx_real_t df_quad(numx_real_t x) { return (numx_real_t)2.0 * x; }
+static numx_real_t f_cubic(numx_real_t x) { return x * x * x - x; }
+static numx_real_t f_xsq(numx_real_t x)   { return x * x; }
+static numx_real_t f_x3(numx_real_t x)    { return x * x * x; }
+static numx_real_t f_sq(numx_real_t x)    { return x * x; }
+
+static numx_status_t ode_decay(numx_real_t t, const numx_real_t *y,
+                                numx_size_t n, numx_real_t *dydt)
+{
+    (void)t; (void)n;
+    dydt[0] = -y[0];
+    return NUMX_OK;
+}
+
+static numx_status_t ode_harm(numx_real_t t, const numx_real_t *y,
+                               numx_size_t n, numx_real_t *dydt)
+{
+    (void)t; (void)n;
+    dydt[0] =  y[1];
+    dydt[1] = -y[0];
+    return NUMX_OK;
+}
+
+/* ── autodiff tape: static to avoid stack overflow (82 KB) ─────────── */
+static numx_ad_tape_t s_tape;
+
+static void ad_bench_cycle(void)
+{
+    numx_size_t ix, ix2, isin, iout;
+    numx_ad_init(&s_tape);
+    numx_ad_var(&s_tape, (numx_real_t)2.0, &ix);
+    numx_ad_mul(&s_tape, ix, ix, &ix2);
+    numx_ad_sin(&s_tape, ix2, &isin);
+    numx_ad_backward(&s_tape, isin);
+    (void)iout;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+ * Main benchmark entry point
+ * ═══════════════════════════════════════════════════════════════════════ */
+
+int main(void)
+{
+    bench_init();
+
+#ifdef NUMX_USE_DOUBLE
+    printf("\n");
+    printf("╔══════════════════════════════════════════════════════════════╗\n");
+    printf("║  Windows x64 Benchmarks (MSVC, float64 / double)            ║\n");
+    printf("║  Rows formatted as markdown table rows.                      ║\n");
+    printf("╚══════════════════════════════════════════════════════════════╝\n");
+#else
+    printf("\n");
+    printf("╔══════════════════════════════════════════════════════════════╗\n");
+    printf("║  Windows x86 Benchmarks (MSVC, float32 / float)             ║\n");
+    printf("║  Rows formatted as markdown table rows.                      ║\n");
+    printf("╚══════════════════════════════════════════════════════════════╝\n");
+#endif
+
+    numx_real_t r;
+
+    /* ══════════════════════════════════════════════════════════════════
+     * linalg
+     * ══════════════════════════════════════════════════════════════════ */
+    printf("\n[linalg]\n");
+
+    numx_real_t a64[64], b64[64];
+    for (int i = 0; i < 64; i++) {
+        a64[i] = (numx_real_t)i;
+        b64[i] = (numx_real_t)(63 - i);
+    }
+
+    bench_section("linalg/vec_dot.md");
+    BENCH("vec_dot n=64", 100000, numx_vec_dot(a64, b64, 64, &r));
+
+    bench_section("linalg/vec_norm.md");
+    BENCH("vec_norm L2 n=64", 100000, numx_vec_norm(a64, 64, NUMX_NORM_L2, &r));
+    BENCH("vec_norm L1 n=64", 100000, numx_vec_norm(a64, 64, NUMX_NORM_L1, &r));
+
+    bench_section("linalg/vec_cross3.md");
+    numx_real_t ax[3] = {(numx_real_t)1, (numx_real_t)2, (numx_real_t)3};
+    numx_real_t bx[3] = {(numx_real_t)4, (numx_real_t)5, (numx_real_t)6};
+    numx_real_t cx[3];
+    BENCH("vec_cross3", 100000, numx_vec_cross3(ax, bx, cx));
+
+    bench_section("linalg/mat_mul.md");
+    numx_real_t A4[16], B4[16], C4[16];
+    for (int i = 0; i < 16; i++) { A4[i] = (numx_real_t)i; B4[i] = (numx_real_t)(15 - i); }
+    BENCH("mat_mul 4x4", 100000, numx_mat_mul(A4, 4, 4, B4, 4, 4, C4));
+    numx_real_t A8[64], B8[64], C8[64], AT8[64];
+    for (int i = 0; i < 64; i++) { A8[i] = (numx_real_t)i * (numx_real_t)0.1; B8[i] = (numx_real_t)(63 - i) * (numx_real_t)0.1; }
+    BENCH("mat_mul 8x8", 10000, numx_mat_mul(A8, 8, 8, B8, 8, 8, C8));
+
+    bench_section("linalg/mat_transpose.md");
+    BENCH("mat_transpose 8x8",    100000, numx_mat_transpose(A8, 8, 8, AT8));
+    BENCH("mat_transpose_sq 8x8", 100000, numx_mat_transpose_sq(A8, 8));
+
+    bench_section("linalg/mat_det.md");
+    numx_real_t Md[16] = {
+        (numx_real_t)4,(numx_real_t)3,(numx_real_t)2,(numx_real_t)1,
+        (numx_real_t)3,(numx_real_t)4,(numx_real_t)3,(numx_real_t)2,
+        (numx_real_t)2,(numx_real_t)3,(numx_real_t)4,(numx_real_t)3,
+        (numx_real_t)1,(numx_real_t)2,(numx_real_t)3,(numx_real_t)4
+    };
+    BENCH("mat_det 4x4", 100000, numx_mat_det(Md, 4, &r));
+
+    bench_section("linalg/lu_solve.md");
+    numx_real_t Alu[16] = {
+        (numx_real_t)2,(numx_real_t)1,(numx_real_t)1,(numx_real_t)0,
+        (numx_real_t)4,(numx_real_t)3,(numx_real_t)3,(numx_real_t)1,
+        (numx_real_t)8,(numx_real_t)7,(numx_real_t)9,(numx_real_t)5,
+        (numx_real_t)6,(numx_real_t)7,(numx_real_t)9,(numx_real_t)8
+    };
+    numx_real_t LU[16], bv[4] = {(numx_real_t)1,(numx_real_t)2,(numx_real_t)4,(numx_real_t)5}, xv[4];
+    numx_idx_t  piv[4];
+    numx_lu_decompose(Alu, 4, LU, piv);
+    BENCH("lu_decompose 4x4",         100000, numx_lu_decompose(Alu, 4, LU, piv));
+    BENCH("lu_solve 4x4 (factored)",  100000, numx_lu_solve(LU, piv, 4, bv, xv));
+
+    /* ══════════════════════════════════════════════════════════════════
+     * stats
+     * ══════════════════════════════════════════════════════════════════ */
+    printf("\n[stats]\n");
+
+    bench_section("stats/stats.md");
+    numx_real_t data[128];
+    for (int i = 0; i < 128; i++) data[i] = (numx_real_t)(i + 1) * (numx_real_t)0.5;
+    BENCH("stats_mean n=128",            100000, numx_stats_mean(data, 128, &r));
+    BENCH("stats_variance pop n=128",    50000,  numx_stats_variance(data, 128, NUMX_VAR_POPULATION, &r));
+    BENCH("stats_variance sample n=128", 50000,  numx_stats_variance(data, 128, NUMX_VAR_SAMPLE, &r));
+    BENCH("stats_median n=128",          10000,  numx_stats_median(data, 128, &r));
+    BENCH("stats_percentile p50 n=128",  10000,  numx_stats_percentile(data, 128, (numx_real_t)50.0, &r));
+    BENCH("stats_percentile p95 n=128",  10000,  numx_stats_percentile(data, 128, (numx_real_t)95.0, &r));
+
+    /* ══════════════════════════════════════════════════════════════════
+     * roots
+     * ══════════════════════════════════════════════════════════════════ */
+    printf("\n[roots]\n");
+
+    bench_section("roots/roots.md");
+    BENCH("root_bisect x^2-4 tol=1e-5", 10000, numx_root_bisect(f_quad, (numx_real_t)0, (numx_real_t)5, (numx_real_t)1e-5, &r));
+    BENCH("root_newton x^2-4 tol=1e-5", 10000, numx_root_newton(f_quad, df_quad, (numx_real_t)3, (numx_real_t)1e-5, &r));
+    BENCH("root_brent  x^2-4 tol=1e-5", 10000, numx_root_brent(f_quad, (numx_real_t)0, (numx_real_t)5, (numx_real_t)1e-5, &r));
+    BENCH("root_brent  x^3-x tol=1e-5", 10000, numx_root_brent(f_cubic, (numx_real_t)0.5, (numx_real_t)1.5, (numx_real_t)1e-5, &r));
+
+    /* ══════════════════════════════════════════════════════════════════
+     * integrate
+     * ══════════════════════════════════════════════════════════════════ */
+    printf("\n[integrate]\n");
+
+    bench_section("integrate/integrate.md");
+    BENCH("integrate_trap n=100",     50000, numx_integrate_trap(f_xsq, (numx_real_t)0, (numx_real_t)1, 100, &r));
+    BENCH("integrate_trap n=1000",    10000, numx_integrate_trap(f_xsq, (numx_real_t)0, (numx_real_t)1, 1000, &r));
+    BENCH("integrate_simpson n=100",  50000, numx_integrate_simpson(f_xsq, (numx_real_t)0, (numx_real_t)1, 100, &r));
+    BENCH("integrate_gauss npts=2",   50000, numx_integrate_gauss(f_xsq, (numx_real_t)0, (numx_real_t)1, 2, &r));
+    BENCH("integrate_gauss npts=4",   50000, numx_integrate_gauss(f_xsq, (numx_real_t)0, (numx_real_t)1, 4, &r));
+    BENCH("integrate_gauss npts=8",   50000, numx_integrate_gauss(f_xsq, (numx_real_t)0, (numx_real_t)1, 8, &r));
+
+    /* ══════════════════════════════════════════════════════════════════
+     * differentiate
+     * ══════════════════════════════════════════════════════════════════ */
+    printf("\n[differentiate]\n");
+
+    bench_section("differentiate/differentiate.md");
+    BENCH("diff_forward  h=1e-3",   100000, numx_diff_forward(f_x3, (numx_real_t)2.0, (numx_real_t)1e-3, &r));
+    BENCH("diff_central  h=1e-3",   100000, numx_diff_central(f_x3, (numx_real_t)2.0, (numx_real_t)1e-3, &r));
+    BENCH("diff_richardson h=1e-3", 100000, numx_diff_richardson(f_x3, (numx_real_t)2.0, (numx_real_t)1e-3, &r));
+
+    /* ══════════════════════════════════════════════════════════════════
+     * interpolate
+     * ══════════════════════════════════════════════════════════════════ */
+    printf("\n[interpolate]\n");
+
+    bench_section("interpolate/interpolate.md");
+    numx_real_t xsi[16], ysi[16], mi[16];
+    for (int i = 0; i < 16; i++) {
+        xsi[i] = (numx_real_t)i * (numx_real_t)(3.14159265 / 15.0);
+        ysi[i] = xsi[i] * xsi[i];
+    }
+    BENCH("interp_linear n=16",            50000, numx_interp_linear(xsi, ysi, 16, (numx_real_t)1.5, &r));
+    BENCH("interp_spline_cubic n=16",      50000, numx_interp_spline_cubic(xsi, ysi, 16, (numx_real_t)1.5, &r));
+    numx_interp_spline_precompute(xsi, ysi, 16, mi);
+    BENCH("interp_spline_eval (precomp)",  50000, numx_interp_spline_eval(xsi, ysi, mi, 16, (numx_real_t)1.5, &r));
+    BENCH("interp_spline_precompute n=16", 50000, numx_interp_spline_precompute(xsi, ysi, 16, mi));
+    BENCH("interp_chebyshev n=8",          50000, numx_interp_chebyshev(f_sq, 8, (numx_real_t)0, (numx_real_t)3.14, (numx_real_t)1.5, &r));
+    BENCH("interp_chebyshev n=16",         10000, numx_interp_chebyshev(f_sq, 16, (numx_real_t)0, (numx_real_t)3.14, (numx_real_t)1.5, &r));
+
+    /* ══════════════════════════════════════════════════════════════════
+     * poly
+     * ══════════════════════════════════════════════════════════════════ */
+    printf("\n[poly]\n");
+
+    bench_section("poly/poly.md");
+    numx_real_t cp8[9] = {
+        (numx_real_t)1,(numx_real_t)0,(numx_real_t)0,(numx_real_t)0,
+        (numx_real_t)-3,(numx_real_t)0,(numx_real_t)0,(numx_real_t)0,(numx_real_t)2
+    };
+    numx_real_t cp3[4] = {(numx_real_t)1,(numx_real_t)-6,(numx_real_t)11,(numx_real_t)-6};
+    numx_real_t pro[3]; numx_size_t pnr;
+    BENCH("poly_eval degree=8",           100000, numx_poly_eval(cp8, 8, (numx_real_t)1.5, &r));
+    BENCH("poly_eval degree=3",           100000, numx_poly_eval(cp3, 3, (numx_real_t)2.5, &r));
+    BENCH("poly_roots degree=3 tol=1e-4",   1000, numx_poly_roots(cp3, 3, pro, &pnr, (numx_real_t)1e-4));
+
+    /* ══════════════════════════════════════════════════════════════════
+     * ode
+     * ══════════════════════════════════════════════════════════════════ */
+    printf("\n[ode]\n");
+
+    bench_section("ode/ode.md");
+    numx_real_t yo[1]  = {(numx_real_t)1.0};
+    numx_real_t yho[2] = {(numx_real_t)1.0, (numx_real_t)0.0};
+    numx_real_t yor[1], yor2[2];
+    BENCH("ode_rk4  decay   n=1 100-steps",  1000, numx_ode_rk4(ode_decay, (numx_real_t)0, yo,  1, (numx_real_t)0.01, 100, yor));
+    BENCH("ode_rk4  harmonic n=2 100-steps", 1000, numx_ode_rk4(ode_harm,  (numx_real_t)0, yho, 2, (numx_real_t)0.01, 100, yor2));
+    BENCH("ode_rk45 decay   n=1 tol=1e-4",  1000, numx_ode_rk45(ode_decay, (numx_real_t)0, (numx_real_t)1.0, yo,  1, (numx_real_t)1e-4, yor));
+    BENCH("ode_rk45 harmonic n=2 tol=1e-4", 1000, numx_ode_rk45(ode_harm,  (numx_real_t)0, (numx_real_t)1.0, yho, 2, (numx_real_t)1e-4, yor2));
+
+    /* ══════════════════════════════════════════════════════════════════
+     * autodiff
+     * ══════════════════════════════════════════════════════════════════ */
+    printf("\n[autodiff]\n");
+
+    bench_section("autodiff/autodiff.md");
+    numx_dual_t dx = numx_dual_var((numx_real_t)2.0);
+    numx_dual_t dc = numx_dual_const((numx_real_t)2.0);
+    BENCH("dual_mul (x*x fwd-mode)",       100000, numx_dual_mul(dx, dx));
+    BENCH("dual_sin (sin(x) fwd-mode)",    100000, numx_dual_sin(dx));
+    BENCH("dual fwd: sin(x^2) full expr",  100000, numx_dual_sin(numx_dual_mul(dx, dx)));
+    BENCH("tape: init+x,x^2,sin+bwd",      10000, ad_bench_cycle());
+    (void)dc;
+
+    /* ══════════════════════════════════════════════════════════════════
+     * fft
+     * ══════════════════════════════════════════════════════════════════ */
+    printf("\n[fft]\n");
+
+    bench_section("fft/fft.md");
+    static numx_real_t fft64[128], fft256[512], fft512[1024], fft256mag[256];
+    static numx_q15_t  fftq256[512];
+    for (int i = 0; i < 128; i++) fft64[i]   = (i & 1) ? (numx_real_t)0 : (numx_real_t)1;
+    for (int i = 0; i < 512; i++) fft256[i]  = (i & 1) ? (numx_real_t)0 : (numx_real_t)1;
+    for (int i = 0; i < 1024; i++) fft512[i] = (i & 1) ? (numx_real_t)0 : (numx_real_t)1;
+    for (int i = 0; i < 512; i++) fftq256[i] = (i & 1) ? 0 : 16384;
+    BENCH("fft_f32 N=64",       10000, numx_fft_f32(fft64,  64));
+    BENCH("fft_f32 N=256",       5000, numx_fft_f32(fft256, 256));
+    BENCH("fft_f32 N=512",       1000, numx_fft_f32(fft512, 512));
+    BENCH("ifft_f32 N=256",      5000, numx_ifft_f32(fft256, 256));
+    BENCH("fft_q15 N=256",       5000, numx_fft_q15(fftq256, 256));
+    for (int i = 0; i < 256; i++) {
+        fft256mag[i] = (numx_real_t)(i % 4 == 0 ? 1 : 0);
+    }
+    BENCH("fft_magnitude N=256", 100000, numx_fft_magnitude(fft256, 256, fft256mag));
+
+    /* ══════════════════════════════════════════════════════════════════
+     * signal
+     * ══════════════════════════════════════════════════════════════════ */
+    printf("\n[signal]\n");
+
+    bench_section("signal/signal.md");
+    static numx_real_t sig_win[64], sig_x64[64], sig_h8[8];
+    static numx_real_t sig_out[128], sig_fir_out[64], sig_iir_out[128];
+    static numx_real_t sig_ema_out[128];
+    static numx_real_t sig_x128[128];
+    static numx_idx_t  sig_peaks[32];
+    static numx_size_t sig_npeaks;
+    numx_real_t sig_biquad_b[3] = {(numx_real_t)1,(numx_real_t)0,(numx_real_t)0};
+    numx_real_t sig_biquad_a[2] = {(numx_real_t)0,(numx_real_t)0};
+    for (int i = 0; i < 64; i++) { sig_x64[i] = (numx_real_t)i; }
+    for (int i = 0; i < 8;  i++) { sig_h8[i]  = (numx_real_t)(i + 1); }
+    for (int i = 0; i < 128; i++) { sig_x128[i] = (numx_real_t)(i % 7); }
+
+    BENCH("signal_window_hann n=64",       100000, numx_signal_window_hann(64, sig_win));
+    BENCH("signal_convolve x=64 h=8",      10000,  numx_signal_convolve(sig_x64, 64, sig_h8, 8, sig_out));
+    BENCH("signal_correlate x=64 y=8",     10000,  numx_signal_correlate(sig_x64, 64, sig_h8, 8, sig_out));
+    BENCH("signal_fir x=128 ntaps=8",      10000,  numx_signal_fir(sig_x128, 128, sig_h8, 8, sig_fir_out));
+    BENCH("signal_iir_biquad n=128",       50000,  numx_signal_iir_biquad(sig_x128, 128, sig_biquad_b, sig_biquad_a, sig_iir_out));
+    BENCH("signal_peaks n=64",             50000,  numx_signal_peaks(sig_x64, 64, sig_peaks, 32, &sig_npeaks));
+    BENCH("signal_ema n=128 alpha=0.1",    50000,  numx_signal_ema(sig_x128, 128, (numx_real_t)0.1, sig_ema_out));
+
+    /* ══════════════════════════════════════════════════════════════════
+     * sketch
+     * ══════════════════════════════════════════════════════════════════ */
+    printf("\n[sketch]\n");
+
+    bench_section("sketch/sketch.md");
+    static numx_real_t sk_A88[64], sk_U88[16], sk_S88[2], sk_Vt88[16];
+    static numx_real_t sk_A1616[256], sk_U1616[64], sk_S1616[4], sk_Vt1616[64];
+    for (int i = 0; i < 64;  i++) sk_A88[i]   = (i == i/8*8+i%8) ? (numx_real_t)(i/8+1) : (numx_real_t)0;
+    for (int i = 0; i < 256; i++) sk_A1616[i] = (i % 16 == i / 16) ? (numx_real_t)(i/16+1) : (numx_real_t)0;
+    BENCH("sketch_rsvd 8x8 rank=2 os=2",   100, numx_sketch_rsvd(sk_A88,   8,  8,  2, 2, 42, sk_U88,   sk_S88,   sk_Vt88));
+    BENCH("sketch_rsvd 16x16 rank=4 os=4", 100, numx_sketch_rsvd(sk_A1616, 16, 16, 4, 4, 42, sk_U1616, sk_S1616, sk_Vt1616));
+
+    /* ══════════════════════════════════════════════════════════════════
+     * compressed_sensing
+     * ══════════════════════════════════════════════════════════════════ */
+    printf("\n[compressed_sensing]\n");
+
+    bench_section("compressed_sensing/compressed_sensing.md");
+    static numx_real_t cs_A[512], cs_y[16], cs_x[32];
+    /* 16x32 sensing matrix: first 16 rows of identity-like structure */
+    memset(cs_A, 0, sizeof(cs_A));
+    for (int i = 0; i < 16; i++) {
+        cs_A[i * 32 + i] = (numx_real_t)1.0;
+        cs_A[i * 32 + i + 16] = (numx_real_t)0.5;
+    }
+    for (int i = 0; i < 16; i++) cs_y[i] = (numx_real_t)(i % 3 == 0 ? 1 : 0);
+
+    numx_real_t cs_sigma;
+    BENCH("cs_spectral_norm 16x32 iter=32", 100, numx_cs_spectral_norm(cs_A, 16, 32, 32, &cs_sigma));
+    BENCH("cs_omp 16x32 k=4",              100, numx_cs_omp(cs_A, cs_y, 16, 32, 4, cs_x));
+    BENCH("cs_ista 16x32 lam=0.1 iter=100", 100, numx_cs_ista(cs_A, cs_y, 16, 32, (numx_real_t)0.1, (numx_real_t)0.9, 100, cs_x));
+
+    printf("\n--- done ---\n");
+    return 0;
+}

--- a/tests/esp32_performance_tests/CMakeLists.txt
+++ b/tests/esp32_performance_tests/CMakeLists.txt
@@ -1,0 +1,11 @@
+idf_component_register(
+    SRCS
+        "bench_runner.c"
+        "math_helpers.c"
+        "bench_phase1.c"
+        "bench_phase2.c"
+    INCLUDE_DIRS "include"
+    PRIV_INCLUDE_DIRS "."
+    PRIV_REQUIRES numx esp_timer freertos esp_system
+)
+target_compile_options(${COMPONENT_LIB} PRIVATE -O2 -std=gnu99 -Wno-unused-parameter)

--- a/tests/esp32_performance_tests/bench_common.h
+++ b/tests/esp32_performance_tests/bench_common.h
@@ -1,0 +1,34 @@
+#ifndef NUMX_BENCH_COMMON_H
+#define NUMX_BENCH_COMMON_H
+
+#include <stdio.h>
+#include "esp_timer.h"
+
+#define BENCH_N_BIG    10000
+#define BENCH_N_MED     5000
+#define BENCH_N_SMALL   1000
+#define BENCH_N_TINY     100
+
+static inline void bprint(const char *lbl, int64_t us, int n)
+{
+    int64_t ns = (us * 1000LL) / n;
+    printf("| %-44s | %6d | %8lld us | %7lld ns |\n",
+           lbl, n, (long long)us, (long long)ns);
+}
+
+static inline void bench_section(const char *target_md)
+{
+    printf("\n  >>> results/%s\n", target_md);
+    printf("  | %-44s | N      | Total us | ns/call  |\n", "Function");
+    printf("  |%-46s|--------|----------|----------|\n",
+           "----------------------------------------------");
+}
+
+#define BENCH(lbl, n, body) do { \
+    int64_t _t0 = esp_timer_get_time(); \
+    for (int _i = 0; _i < (n); _i++) { body; } \
+    int64_t _t1 = esp_timer_get_time(); \
+    printf("  "); bprint((lbl), _t1 - _t0, (n)); \
+} while (0)
+
+#endif /* NUMX_BENCH_COMMON_H */

--- a/tests/esp32_performance_tests/bench_phase1.c
+++ b/tests/esp32_performance_tests/bench_phase1.c
@@ -1,0 +1,177 @@
+#include <stdio.h>
+#include "bench_common.h"
+#include "math_helpers.h"
+#include "numx/linalg.h"
+#include "numx/stats.h"
+#include "numx/roots.h"
+#include "numx/integrate.h"
+#include "numx/differentiate.h"
+#include "numx/interpolate.h"
+#include "numx/poly.h"
+#include "numx/ode.h"
+
+void bench_phase1(void)
+{
+    printf("\n");
+    printf("╔══════════════════════════════════════════════════════════════╗\n");
+    printf("║  PHASE 1 — linalg / stats / roots / integrate /             ║\n");
+    printf("║            differentiate / interpolate / poly / ode          ║\n");
+    printf("║  ESP32-S3 @ 240 MHz · float32                               ║\n");
+    printf("║  Copy each >>> block into the matching results/*.md file.   ║\n");
+    printf("╚══════════════════════════════════════════════════════════════╝\n");
+
+    /* ── shared data ─────────────────────────────────────────────────── */
+    numx_real_t a64[64], b64[64], r;
+    for (int i = 0; i < 64; i++) {
+        a64[i] = (numx_real_t)i;
+        b64[i] = (numx_real_t)(63 - i);
+    }
+
+    /* ══════════════════════════════════════════════════════════════════ */
+    printf("\n[linalg]\n");
+
+    bench_section("linalg/vec_dot.md");
+    BENCH("vec_dot n=64", BENCH_N_BIG,
+          numx_vec_dot(a64, b64, 64, &r));
+
+    bench_section("linalg/vec_norm.md");
+    BENCH("vec_norm L2 n=64", BENCH_N_BIG,
+          numx_vec_norm(a64, 64, NUMX_NORM_L2, &r));
+    BENCH("vec_norm L1 n=64", BENCH_N_BIG,
+          numx_vec_norm(a64, 64, NUMX_NORM_L1, &r));
+
+    bench_section("linalg/vec_cross3.md");
+    numx_real_t ax3[3] = {1.0f, 2.0f, 3.0f};
+    numx_real_t bx3[3] = {4.0f, 5.0f, 6.0f};
+    numx_real_t cx3[3];
+    BENCH("vec_cross3", BENCH_N_BIG,
+          numx_vec_cross3(ax3, bx3, cx3));
+
+    bench_section("linalg/mat_mul.md");
+    numx_real_t A4[16], B4[16], C4[16];
+    for (int i = 0; i < 16; i++) { A4[i] = (numx_real_t)i; B4[i] = (numx_real_t)(15 - i); }
+    BENCH("mat_mul 4x4", BENCH_N_BIG,
+          numx_mat_mul(A4, 4, 4, B4, 4, 4, C4));
+    numx_real_t A8[64], B8[64], C8[64];
+    for (int i = 0; i < 64; i++) { A8[i] = (numx_real_t)i * 0.1f; B8[i] = (numx_real_t)(63 - i) * 0.1f; }
+    BENCH("mat_mul 8x8", BENCH_N_TINY,
+          numx_mat_mul(A8, 8, 8, B8, 8, 8, C8));
+
+    bench_section("linalg/mat_transpose.md");
+    numx_real_t AT8[64];
+    for (int i = 0; i < 64; i++) A8[i] = (numx_real_t)i;
+    BENCH("mat_transpose 8x8",    BENCH_N_BIG, numx_mat_transpose(A8, 8, 8, AT8));
+    BENCH("mat_transpose_sq 8x8", BENCH_N_BIG, numx_mat_transpose_sq(A8, 8));
+
+    bench_section("linalg/mat_det.md");
+    numx_real_t Md[16] = {4, 3, 2, 1, 3, 4, 3, 2, 2, 3, 4, 3, 1, 2, 3, 4};
+    BENCH("mat_det 4x4", BENCH_N_BIG,
+          numx_mat_det(Md, 4, &r));
+
+    bench_section("linalg/lu_solve.md");
+    numx_real_t Alu[16] = {2, 1, 1, 0, 4, 3, 3, 1, 8, 7, 9, 5, 6, 7, 9, 8};
+    numx_real_t LU[16], bv[4] = {1, 2, 4, 5}, xv[4];
+    numx_idx_t  piv[4];
+    numx_lu_decompose(Alu, 4, LU, piv);
+    BENCH("lu_decompose 4x4",        BENCH_N_BIG, numx_lu_decompose(Alu, 4, LU, piv));
+    BENCH("lu_solve 4x4 (factored)", BENCH_N_BIG, numx_lu_solve(LU, piv, 4, bv, xv));
+
+    /* ══════════════════════════════════════════════════════════════════ */
+    printf("\n[stats]\n");
+
+    bench_section("stats/stats.md");
+    numx_real_t data[128];
+    for (int i = 0; i < 128; i++) data[i] = (numx_real_t)(i + 1) * 0.5f;
+    BENCH("stats_mean n=128",            BENCH_N_BIG,   numx_stats_mean(data, 128, &r));
+    BENCH("stats_variance pop n=128",    BENCH_N_MED,   numx_stats_variance(data, 128, NUMX_VAR_POPULATION, &r));
+    BENCH("stats_variance sample n=128", BENCH_N_MED,   numx_stats_variance(data, 128, NUMX_VAR_SAMPLE, &r));
+    BENCH("stats_median n=128",          BENCH_N_SMALL, numx_stats_median(data, 128, &r));
+    BENCH("stats_percentile p50 n=128",  BENCH_N_SMALL, numx_stats_percentile(data, 128, 50.0f, &r));
+    BENCH("stats_percentile p95 n=128",  BENCH_N_SMALL, numx_stats_percentile(data, 128, 95.0f, &r));
+
+    /* ══════════════════════════════════════════════════════════════════ */
+    printf("\n[roots]\n");
+
+    bench_section("roots/roots.md");
+    BENCH("root_bisect x^2-4 tol=1e-5", BENCH_N_SMALL,
+          numx_root_bisect(f_quad, 0.0f, 5.0f, 1e-5f, &r));
+    BENCH("root_newton x^2-4 tol=1e-5", BENCH_N_SMALL,
+          numx_root_newton(f_quad, df_quad, 3.0f, 1e-5f, &r));
+    BENCH("root_brent  x^2-4 tol=1e-5", BENCH_N_SMALL,
+          numx_root_brent(f_quad, 0.0f, 5.0f, 1e-5f, &r));
+    BENCH("root_brent  x^3-x tol=1e-5", BENCH_N_SMALL,
+          numx_root_brent(f_cubic, 0.5f, 1.5f, 1e-5f, &r));
+
+    /* ══════════════════════════════════════════════════════════════════ */
+    printf("\n[integrate]\n");
+
+    bench_section("integrate/integrate.md");
+    BENCH("integrate_trap n=100",    BENCH_N_MED,   numx_integrate_trap(f_xsq, 0.0f, 1.0f, 100, &r));
+    BENCH("integrate_trap n=1000",   BENCH_N_SMALL, numx_integrate_trap(f_xsq, 0.0f, 1.0f, 1000, &r));
+    BENCH("integrate_simpson n=100", BENCH_N_MED,   numx_integrate_simpson(f_xsq, 0.0f, 1.0f, 100, &r));
+    BENCH("integrate_gauss npts=2",  BENCH_N_MED,   numx_integrate_gauss(f_xsq, 0.0f, 1.0f, 2, &r));
+    BENCH("integrate_gauss npts=4",  BENCH_N_MED,   numx_integrate_gauss(f_xsq, 0.0f, 1.0f, 4, &r));
+    BENCH("integrate_gauss npts=8",  BENCH_N_MED,   numx_integrate_gauss(f_xsq, 0.0f, 1.0f, 8, &r));
+
+    /* ══════════════════════════════════════════════════════════════════ */
+    printf("\n[differentiate]\n");
+
+    bench_section("differentiate/differentiate.md");
+    BENCH("diff_forward  h=1e-3",   BENCH_N_BIG, numx_diff_forward(f_x3,    2.0f, 1e-3f, &r));
+    BENCH("diff_central  h=1e-3",   BENCH_N_BIG, numx_diff_central(f_x3,    2.0f, 1e-3f, &r));
+    BENCH("diff_richardson h=1e-3", BENCH_N_BIG, numx_diff_richardson(f_x3, 2.0f, 1e-3f, &r));
+
+    /* ══════════════════════════════════════════════════════════════════ */
+    printf("\n[interpolate]\n");
+
+    bench_section("interpolate/interpolate.md");
+    numx_real_t xsi[16], ysi[16], mi[16];
+    for (int i = 0; i < 16; i++) {
+        xsi[i] = (numx_real_t)i * (3.14159f / 15.0f);
+        ysi[i] = xsi[i] * xsi[i];
+    }
+    BENCH("interp_linear n=16",            BENCH_N_MED,
+          numx_interp_linear(xsi, ysi, 16, 1.5f, &r));
+    BENCH("interp_spline_cubic n=16",      BENCH_N_MED,
+          numx_interp_spline_cubic(xsi, ysi, 16, 1.5f, &r));
+    numx_interp_spline_precompute(xsi, ysi, 16, mi);
+    BENCH("interp_spline_eval (precomp)",  BENCH_N_MED,
+          numx_interp_spline_eval(xsi, ysi, mi, 16, 1.5f, &r));
+    BENCH("interp_spline_precompute n=16", BENCH_N_MED,
+          numx_interp_spline_precompute(xsi, ysi, 16, mi));
+    BENCH("interp_chebyshev n=8",          BENCH_N_MED,
+          numx_interp_chebyshev(f_sq, 8, 0.0f, 3.14f, 1.5f, &r));
+    BENCH("interp_chebyshev n=16",         BENCH_N_SMALL,
+          numx_interp_chebyshev(f_sq, 16, 0.0f, 3.14f, 1.5f, &r));
+
+    /* ══════════════════════════════════════════════════════════════════ */
+    printf("\n[poly]\n");
+
+    bench_section("poly/poly.md");
+    numx_real_t cp8[9] = {1, 0, 0, 0, -3, 0, 0, 0, 2};
+    numx_real_t cp3[4] = {1, -6, 11, -6};
+    numx_real_t pro[3];
+    numx_size_t pnr;
+    BENCH("poly_eval degree=8",           BENCH_N_BIG,
+          numx_poly_eval(cp8, 8, 1.5f, &r));
+    BENCH("poly_eval degree=3",           BENCH_N_BIG,
+          numx_poly_eval(cp3, 3, 2.5f, &r));
+    BENCH("poly_roots degree=3 tol=1e-4", BENCH_N_TINY,
+          numx_poly_roots(cp3, 3, pro, &pnr, 1e-4f));
+
+    /* ══════════════════════════════════════════════════════════════════ */
+    printf("\n[ode]\n");
+
+    bench_section("ode/ode.md");
+    numx_real_t yo[1]  = {1.0f};
+    numx_real_t yho[2] = {1.0f, 0.0f};
+    numx_real_t yor[1], yor2[2];
+    BENCH("ode_rk4  decay   n=1 100-steps",  BENCH_N_SMALL,
+          numx_ode_rk4(ode_decay, 0.0f, yo,  1, 0.01f, 100, yo));
+    BENCH("ode_rk4  harmonic n=2 100-steps", BENCH_N_SMALL,
+          numx_ode_rk4(ode_harm,  0.0f, yho, 2, 0.01f, 100, yho));
+    BENCH("ode_rk45 decay   n=1 tol=1e-4",   BENCH_N_SMALL,
+          numx_ode_rk45(ode_decay, 0.0f, 1.0f, yo,  1, 1e-4f, yor));
+    BENCH("ode_rk45 harmonic n=2 tol=1e-4",  BENCH_N_SMALL,
+          numx_ode_rk45(ode_harm,  0.0f, 1.0f, yho, 2, 1e-4f, yor2));
+}

--- a/tests/esp32_performance_tests/bench_phase2.c
+++ b/tests/esp32_performance_tests/bench_phase2.c
@@ -1,0 +1,170 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+#include "bench_common.h"
+#include "numx/autodiff.h"
+#include "numx/fft.h"
+#include "numx/signal.h"
+#include "numx/sketch.h"
+#include "numx/compressed_sensing.h"
+
+/* ── autodiff: tape is ~82 KB — must be static ──────────────────────── */
+static numx_ad_tape_t s_ad_tape;
+
+static void ad_bench_cycle(void)
+{
+    numx_size_t xi, qi, si;
+    numx_ad_init(&s_ad_tape);
+    numx_ad_var(&s_ad_tape, 1.5f, &xi);
+    numx_ad_mul(&s_ad_tape, xi, xi, &qi);
+    numx_ad_sin(&s_ad_tape, qi, &si);
+    numx_ad_backward(&s_ad_tape, si);
+}
+
+/* ── fft buffers ─────────────────────────────────────────────────────── */
+static numx_real_t fft64[128];      /* 64 complex pairs */
+static numx_real_t fft256[512];     /* 256 complex pairs */
+static numx_real_t fft512[1024];    /* 512 complex pairs */
+static numx_q15_t  q15_256[512];    /* 256 complex Q15 pairs */
+static numx_real_t fft_mag[257];    /* magnitude bins for n=256 */
+
+/* ── signal buffers ──────────────────────────────────────────────────── */
+static numx_real_t sig_x64[64];
+static numx_real_t sig_h8[8];
+static numx_real_t sig_conv_out[71];   /* 64 + 8 - 1 */
+static numx_real_t sig_corr_out[71];
+static numx_real_t sig_x128[128];
+static numx_real_t sig_out128[128];
+static numx_real_t sig_win64[64];
+static numx_size_t sig_peaks[32];
+static numx_size_t sig_npeaks;
+
+static const numx_real_t fir_taps[8] = {
+    0.0625f, 0.125f, 0.25f, 0.5f, 0.5f, 0.25f, 0.125f, 0.0625f
+};
+static const numx_real_t iir_b[3] = { 0.0675f,  0.1349f,  0.0675f };
+static const numx_real_t iir_a[2] = {-1.1430f,  0.4128f };
+
+/* ── sketch buffers ──────────────────────────────────────────────────── */
+static numx_real_t sk_A8[64];    /* 8x8 input */
+static numx_real_t sk_U8[16];    /* 8x2 */
+static numx_real_t sk_S8[2];
+static numx_real_t sk_Vt8[16];   /* 2x8 */
+
+static numx_real_t sk_A16[256];  /* 16x16 input */
+static numx_real_t sk_U16[64];   /* 16x4 */
+static numx_real_t sk_S16[4];
+static numx_real_t sk_Vt16[64];  /* 4x16 */
+
+/* ── compressed-sensing buffers ──────────────────────────────────────── */
+static numx_real_t cs_A[512];    /* 16x32 */
+static numx_real_t cs_y[16];
+static numx_real_t cs_x[32];
+static numx_real_t cs_sigma;
+
+void bench_phase2(void)
+{
+    printf("\n");
+    printf("╔══════════════════════════════════════════════════════════════╗\n");
+    printf("║  PHASE 2 — autodiff / fft / signal / sketch /               ║\n");
+    printf("║            compressed_sensing                                ║\n");
+    printf("║  ESP32-S3 @ 240 MHz · float32                               ║\n");
+    printf("║  Copy each >>> block into the matching results/*.md file.   ║\n");
+    printf("╚══════════════════════════════════════════════════════════════╝\n");
+
+    /* ══════════════════════════════════════════════════════════════════ */
+    printf("\n[autodiff]\n");
+
+    bench_section("autodiff/autodiff.md");
+    {
+        numx_dual_t xd, sq, sn;
+        BENCH("dual_mul (x*x fwd-mode)",       BENCH_N_BIG, (
+            xd = numx_dual_var(1.5f),
+            sq = numx_dual_mul(xd, xd),
+            (void)sq));
+        BENCH("dual_sin (sin(x) fwd-mode)",    BENCH_N_BIG, (
+            xd = numx_dual_var(1.5f),
+            sn = numx_dual_sin(xd),
+            (void)sn));
+        BENCH("dual fwd: sin(x^2) full expr",  BENCH_N_BIG, (
+            xd = numx_dual_var(1.5f),
+            sq = numx_dual_mul(xd, xd),
+            sn = numx_dual_sin(sq),
+            (void)sn));
+        BENCH("tape: init+x,x^2,sin+bwd", BENCH_N_SMALL,
+              ad_bench_cycle());
+    }
+
+    /* ══════════════════════════════════════════════════════════════════ */
+    printf("\n[fft]\n");
+
+    /* Initialise buffers: real signal, zero imaginary */
+    for (int i = 0; i < 128; i++) fft64[i]  = (i % 2 == 0) ? (numx_real_t)(i/2 + 1) * 0.1f : 0.0f;
+    for (int i = 0; i < 512; i++) fft256[i] = (i % 2 == 0) ? (numx_real_t)(i/2 + 1) * 0.1f : 0.0f;
+    for (int i = 0; i < 1024; i++) fft512[i] = (i % 2 == 0) ? (numx_real_t)(i/2 + 1) * 0.1f : 0.0f;
+    for (int i = 0; i < 512; i++) q15_256[i] = (numx_q15_t)((i % 2 == 0) ? 1000 : 0);
+
+    bench_section("fft/fft.md");
+    BENCH("fft_f32 N=64",         BENCH_N_MED,   numx_fft_f32(fft64,  64));
+    BENCH("fft_f32 N=256",        BENCH_N_SMALL, numx_fft_f32(fft256, 256));
+    BENCH("fft_f32 N=512",        BENCH_N_TINY,  numx_fft_f32(fft512, 512));
+    BENCH("ifft_f32 N=256",       BENCH_N_SMALL, numx_ifft_f32(fft256, 256));
+    BENCH("fft_q15 N=256",        BENCH_N_SMALL, numx_fft_q15(q15_256, 256));
+    BENCH("fft_magnitude N=256",  BENCH_N_BIG,   numx_fft_magnitude(fft256, 256, fft_mag));
+
+    /* ══════════════════════════════════════════════════════════════════ */
+    printf("\n[signal]\n");
+
+    /* Initialise buffers */
+    for (int i = 0; i < 64; i++)  sig_x64[i]  = (numx_real_t)(i % 8) * 0.5f;
+    for (int i = 0; i < 8; i++)   sig_h8[i]   = 0.125f;
+    for (int i = 0; i < 128; i++) sig_x128[i] = (numx_real_t)(i % 16) * 0.25f;
+
+    bench_section("signal/signal.md");
+    BENCH("signal_window_hann n=64",      BENCH_N_BIG,
+          numx_signal_window_hann(64, sig_win64));
+    BENCH("signal_convolve x=64 h=8",     BENCH_N_SMALL,
+          numx_signal_convolve(sig_x64, 64, sig_h8, 8, sig_conv_out));
+    BENCH("signal_correlate x=64 y=8",    BENCH_N_SMALL,
+          numx_signal_correlate(sig_x64, 64, sig_h8, 8, sig_corr_out));
+    BENCH("signal_fir x=128 ntaps=8",     BENCH_N_SMALL,
+          numx_signal_fir(sig_x128, 128, fir_taps, 8, sig_out128));
+    BENCH("signal_iir_biquad n=128",      BENCH_N_MED,
+          numx_signal_iir_biquad(sig_x128, 128, iir_b, iir_a, sig_out128));
+    BENCH("signal_peaks n=64",            BENCH_N_MED,
+          numx_signal_peaks(sig_x64, 64, sig_peaks, 32, &sig_npeaks));
+    BENCH("signal_ema n=128 alpha=0.1",   BENCH_N_MED,
+          numx_signal_ema(sig_x128, 128, 0.1f, sig_out128));
+
+    /* ══════════════════════════════════════════════════════════════════ */
+    printf("\n[sketch]\n");
+
+    /* Initialise A matrices: diagonal-dominant values */
+    for (int i = 0; i < 64; i++)  sk_A8[i]  = (i % 9 == 0) ? 2.0f : 0.1f;
+    for (int i = 0; i < 256; i++) sk_A16[i] = (i % 17 == 0) ? 3.0f : 0.1f;
+
+    bench_section("sketch/sketch.md");
+    BENCH("sketch_rsvd 8x8 rank=2 os=2",   BENCH_N_TINY,
+          numx_sketch_rsvd(sk_A8, 8, 8, 2, 2, 42u, sk_U8, sk_S8, sk_Vt8));
+    BENCH("sketch_rsvd 16x16 rank=4 os=4", BENCH_N_TINY,
+          numx_sketch_rsvd(sk_A16, 16, 16, 4, 4, 42u, sk_U16, sk_S16, sk_Vt16));
+
+    /* ══════════════════════════════════════════════════════════════════ */
+    printf("\n[compressed_sensing]\n");
+
+    /* Initialise A as a simple Bernoulli-like matrix, y as sparse signal */
+    for (int i = 0; i < 512; i++) cs_A[i] = (i % 17 == 0) ? 1.0f : 0.1f;
+    memset(cs_y, 0, sizeof(cs_y));
+    cs_y[0] = 1.0f;
+    cs_y[3] = 0.5f;
+
+    bench_section("compressed_sensing/compressed_sensing.md");
+    BENCH("cs_spectral_norm 16x32 iter=32", BENCH_N_TINY,
+          numx_cs_spectral_norm(cs_A, 16, 32, 32, &cs_sigma));
+    memset(cs_x, 0, sizeof(cs_x));
+    BENCH("cs_omp 16x32 k=4",               BENCH_N_TINY,
+          numx_cs_omp(cs_A, cs_y, 16, 32, 4, cs_x));
+    memset(cs_x, 0, sizeof(cs_x));
+    BENCH("cs_ista 16x32 lam=0.1 iter=100", BENCH_N_TINY,
+          numx_cs_ista(cs_A, cs_y, 16, 32, 0.1f, 0.05f, 100, cs_x));
+}

--- a/tests/esp32_performance_tests/bench_runner.c
+++ b/tests/esp32_performance_tests/bench_runner.c
@@ -1,0 +1,20 @@
+#include <stdio.h>
+#include "esp32_performance_tests.h"
+
+void run_performance_tests(void)
+{
+    printf("\n");
+    printf("╔══════════════════════════════════════════════════════════════╗\n");
+    printf("║  numx PERFORMANCE BENCHMARK SUITE                           ║\n");
+    printf("║  ESP32-S3 @ 240 MHz · float32 · ESP-IDF v5.5.2             ║\n");
+    printf("╚══════════════════════════════════════════════════════════════╝\n");
+
+    bench_phase1();
+    bench_phase2();
+
+    printf("\n");
+    printf("╔══════════════════════════════════════════════════════════════╗\n");
+    printf("║  Benchmark complete.                                         ║\n");
+    printf("║  Paste each >>> block into the matching results/*.md file.  ║\n");
+    printf("╚══════════════════════════════════════════════════════════════╝\n");
+}

--- a/tests/esp32_performance_tests/include/esp32_performance_tests.h
+++ b/tests/esp32_performance_tests/include/esp32_performance_tests.h
@@ -1,0 +1,15 @@
+#ifndef NUMX_ESP32_PERFORMANCE_TESTS_H
+#define NUMX_ESP32_PERFORMANCE_TESTS_H
+
+/* Run all Phase 1 benchmarks (linalg, stats, roots, integrate,
+   differentiate, interpolate, poly, ode). */
+void bench_phase1(void);
+
+/* Run all Phase 2 benchmarks (autodiff, fft, signal, sketch,
+   compressed_sensing). */
+void bench_phase2(void);
+
+/* Run Phase 1 + Phase 2 in sequence. */
+void run_performance_tests(void);
+
+#endif /* NUMX_ESP32_PERFORMANCE_TESTS_H */

--- a/tests/esp32_performance_tests/math_helpers.c
+++ b/tests/esp32_performance_tests/math_helpers.c
@@ -1,0 +1,17 @@
+#include "math_helpers.h"
+
+numx_real_t f_quad(numx_real_t x)  { return x*x - 4.0f; }
+numx_real_t df_quad(numx_real_t x) { return 2.0f*x; }
+
+numx_real_t f_cubic(numx_real_t x)  { return x*x*x - x; }
+numx_real_t df_cubic(numx_real_t x) { return 3.0f*x*x - 1.0f; }
+
+numx_real_t f_xsq(numx_real_t x)  { return x*x; }
+numx_real_t f_x3(numx_real_t x)   { return x*x*x; }
+numx_real_t f_sq(numx_real_t x)   { return x*x; }
+
+numx_status_t ode_decay(numx_real_t t, const numx_real_t *y, numx_size_t n, numx_real_t *d)
+{ (void)t; (void)n; d[0] = -y[0]; return NUMX_OK; }
+
+numx_status_t ode_harm(numx_real_t t, const numx_real_t *y, numx_size_t n, numx_real_t *d)
+{ (void)t; (void)n; d[0] = y[1]; d[1] = -y[0]; return NUMX_OK; }

--- a/tests/esp32_performance_tests/math_helpers.h
+++ b/tests/esp32_performance_tests/math_helpers.h
@@ -1,0 +1,17 @@
+#ifndef NUMX_PERF_MATH_HELPERS_H
+#define NUMX_PERF_MATH_HELPERS_H
+
+#include "numx/numx_types.h"
+
+numx_real_t f_quad(numx_real_t x);
+numx_real_t df_quad(numx_real_t x);
+numx_real_t f_cubic(numx_real_t x);
+numx_real_t df_cubic(numx_real_t x);
+numx_real_t f_xsq(numx_real_t x);
+numx_real_t f_x3(numx_real_t x);
+numx_real_t f_sq(numx_real_t x);
+
+numx_status_t ode_decay(numx_real_t t, const numx_real_t *y, numx_size_t n, numx_real_t *d);
+numx_status_t ode_harm(numx_real_t t, const numx_real_t *y, numx_size_t n, numx_real_t *d);
+
+#endif /* NUMX_PERF_MATH_HELPERS_H */

--- a/tests/esp32_tests/CMakeLists.txt
+++ b/tests/esp32_tests/CMakeLists.txt
@@ -1,0 +1,24 @@
+idf_component_register(
+    SRCS
+        "esp32_tests.c"
+        "test_helpers.c"
+        "math_helpers.c"
+        "test_linalg.c"
+        "test_stats.c"
+        "test_roots.c"
+        "test_integrate.c"
+        "test_differentiate.c"
+        "test_interpolate.c"
+        "test_poly.c"
+        "test_ode.c"
+        "test_signal.c"
+        "test_fft.c"
+        "test_autodiff.c"
+        "test_compressed_sensing.c"
+        "test_sketch.c"
+        "bench.c"
+    INCLUDE_DIRS "include"
+    PRIV_INCLUDE_DIRS "."
+    PRIV_REQUIRES numx esp_timer freertos esp_system
+)
+target_compile_options(${COMPONENT_LIB} PRIVATE -O2 -std=gnu99 -Wno-unused-parameter)

--- a/tests/esp32_tests/bench.c
+++ b/tests/esp32_tests/bench.c
@@ -1,0 +1,173 @@
+#include <stdio.h>
+#include "esp_timer.h"
+#include "math_helpers.h"
+#include "numx/linalg.h"
+#include "numx/stats.h"
+#include "numx/roots.h"
+#include "numx/integrate.h"
+#include "numx/differentiate.h"
+#include "numx/interpolate.h"
+#include "numx/poly.h"
+#include "numx/ode.h"
+
+#define BENCH_N_BIG   10000
+#define BENCH_N_MED    5000
+#define BENCH_N_SMALL  1000
+#define BENCH_N_TINY    100
+
+/* Print one markdown table row: | function | N | total_us | ns/call | */
+static void bprint(const char *lbl, int64_t us, int n)
+{
+    int64_t ns = (us * 1000LL) / n;
+    printf("| %-44s | %6d | %8lld us | %7lld ns |\n",
+           lbl, n, (long long)us, (long long)ns);
+}
+
+/* Print section header pointing at the target .md file */
+static void bench_section(const char *target_md)
+{
+    printf("\n  >>> results/%s\n", target_md);
+    printf("  | %-44s | N      | Total us | ns/call  |\n",
+           "Function");
+    printf("  |%-46s|--------|----------|----------|\n",
+           "----------------------------------------------");
+}
+
+#define BENCH(lbl, n, body) do { \
+    int64_t _t0 = esp_timer_get_time(); \
+    for (int _i = 0; _i < (n); _i++) { body; } \
+    int64_t _t1 = esp_timer_get_time(); \
+    printf("  "); bprint((lbl), _t1 - _t0, (n)); \
+} while (0)
+
+void run_benchmarks(void)
+{
+    printf("\n");
+    printf("╔══════════════════════════════════════════════════════════════╗\n");
+    printf("║  SECTION 2 — Benchmarks (ESP32-S3 @ 240 MHz, float32)        ║\n");
+    printf("║  Rows below are formatted as markdown table rows.            ║\n");
+    printf("║  Copy each >>> block into the matching results/*.md file.    ║\n");
+    printf("╚══════════════════════════════════════════════════════════════╝\n");
+
+    /* ── shared data ──────────────────────────────────────────────── */
+    numx_real_t a64[64], b64[64], r;
+    for (int i = 0; i < 64; i++) { a64[i] = (numx_real_t)i; b64[i] = (float)(63 - i); }
+
+    /* ══════════════════════════════════════════════════════════════ */
+    printf("\n[linalg]\n");
+
+    bench_section("linalg/vec_dot.md");
+    BENCH("vec_dot n=64", BENCH_N_BIG, numx_vec_dot(a64, b64, 64, &r));
+
+    bench_section("linalg/vec_norm.md");
+    BENCH("vec_norm L2 n=64", BENCH_N_BIG, numx_vec_norm(a64, 64, NUMX_NORM_L2, &r));
+    BENCH("vec_norm L1 n=64", BENCH_N_BIG, numx_vec_norm(a64, 64, NUMX_NORM_L1, &r));
+
+    bench_section("linalg/vec_cross3.md");
+    numx_real_t ax3[3] = {1, 2, 3}, bx3[3] = {4, 5, 6}, cx[3];
+    BENCH("vec_cross3", BENCH_N_BIG, numx_vec_cross3(ax3, bx3, cx));
+
+    bench_section("linalg/mat_mul.md");
+    numx_real_t A4[16], B4[16], C4[16];
+    for (int i = 0; i < 16; i++) { A4[i] = (numx_real_t)i; B4[i] = (float)(15 - i); }
+    BENCH("mat_mul 4x4", BENCH_N_BIG, numx_mat_mul(A4, 4, 4, B4, 4, 4, C4));
+    numx_real_t A8[64], B8[64], C8[64];
+    for (int i = 0; i < 64; i++) { A8[i] = (numx_real_t)i * 0.1f; B8[i] = (float)(63 - i) * 0.1f; }
+    BENCH("mat_mul 8x8", BENCH_N_TINY, numx_mat_mul(A8, 8, 8, B8, 8, 8, C8));
+
+    /* mat_transpose — no dedicated .md file, included for completeness */
+    printf("\n  >>> linalg/mat_mul.md (mat_transpose extras)\n");
+    printf("  | %-44s | N      | Total us | ns/call  |\n", "Function");
+    printf("  |%-46s|--------|----------|----------|\n", "----------------------------------------------");
+    numx_real_t AT[64];
+    for (int i = 0; i < 64; i++) A8[i] = (numx_real_t)i;
+    BENCH("mat_transpose 8x8",    BENCH_N_BIG, numx_mat_transpose(A8, 8, 8, AT));
+    BENCH("mat_transpose_sq 8x8", BENCH_N_BIG, numx_mat_transpose_sq(A8, 8));
+
+    bench_section("linalg/mat_det.md");
+    numx_real_t Md[16] = {4, 3, 2, 1, 3, 4, 3, 2, 2, 3, 4, 3, 1, 2, 3, 4};
+    BENCH("mat_det 4x4", BENCH_N_BIG, numx_mat_det(Md, 4, &r));
+
+    bench_section("linalg/lu_solve.md");
+    numx_real_t Alu[16] = {2, 1, 1, 0, 4, 3, 3, 1, 8, 7, 9, 5, 6, 7, 9, 8};
+    numx_real_t LU[16], bv[4] = {1, 2, 4, 5}, xv[4];
+    numx_idx_t  piv[4];
+    numx_lu_decompose(Alu, 4, LU, piv);
+    BENCH("lu_decompose 4x4",      BENCH_N_BIG, numx_lu_decompose(Alu, 4, LU, piv));
+    BENCH("lu_solve 4x4 (factored)", BENCH_N_BIG, numx_lu_solve(LU, piv, 4, bv, xv));
+
+    /* ══════════════════════════════════════════════════════════════ */
+    printf("\n[stats]\n");
+
+    bench_section("stats/stats.md");
+    numx_real_t data[128];
+    for (int i = 0; i < 128; i++) data[i] = (float)(i + 1) * 0.5f;
+    BENCH("stats_mean n=128",            BENCH_N_BIG,   numx_stats_mean(data, 128, &r));
+    BENCH("stats_variance pop n=128",    BENCH_N_MED,   numx_stats_variance(data, 128, NUMX_VAR_POPULATION, &r));
+    BENCH("stats_variance sample n=128", BENCH_N_MED,   numx_stats_variance(data, 128, NUMX_VAR_SAMPLE, &r));
+    BENCH("stats_median n=128",          BENCH_N_SMALL, numx_stats_median(data, 128, &r));
+    BENCH("stats_percentile p50 n=128",  BENCH_N_SMALL, numx_stats_percentile(data, 128, 50.0f, &r));
+    BENCH("stats_percentile p95 n=128",  BENCH_N_SMALL, numx_stats_percentile(data, 128, 95.0f, &r));
+
+    /* ══════════════════════════════════════════════════════════════ */
+    printf("\n[roots]\n");
+
+    bench_section("roots/roots.md");
+    BENCH("root_bisect x^2-4 tol=1e-5", BENCH_N_SMALL, numx_root_bisect(f_quad, 0, 5, 1e-5f, &r));
+    BENCH("root_newton x^2-4 tol=1e-5", BENCH_N_SMALL, numx_root_newton(f_quad, df_quad, 3, 1e-5f, &r));
+    BENCH("root_brent  x^2-4 tol=1e-5", BENCH_N_SMALL, numx_root_brent(f_quad, 0, 5, 1e-5f, &r));
+    BENCH("root_brent  x^3-x tol=1e-5", BENCH_N_SMALL, numx_root_brent(f_cubic, 0.5f, 1.5f, 1e-5f, &r));
+
+    /* ══════════════════════════════════════════════════════════════ */
+    printf("\n[integrate]\n");
+
+    bench_section("integrate/integrate.md");
+    BENCH("integrate_trap n=100",     BENCH_N_MED,   numx_integrate_trap(f_xsq, 0, 1, 100, &r));
+    BENCH("integrate_trap n=1000",    BENCH_N_SMALL, numx_integrate_trap(f_xsq, 0, 1, 1000, &r));
+    BENCH("integrate_simpson n=100",  BENCH_N_MED,   numx_integrate_simpson(f_xsq, 0, 1, 100, &r));
+    BENCH("integrate_gauss npts=2",   BENCH_N_MED,   numx_integrate_gauss(f_xsq, 0, 1, 2, &r));
+    BENCH("integrate_gauss npts=4",   BENCH_N_MED,   numx_integrate_gauss(f_xsq, 0, 1, 4, &r));
+    BENCH("integrate_gauss npts=8",   BENCH_N_MED,   numx_integrate_gauss(f_xsq, 0, 1, 8, &r));
+
+    /* ══════════════════════════════════════════════════════════════ */
+    printf("\n[differentiate]\n");
+
+    bench_section("differentiate/differentiate.md");
+    BENCH("diff_forward  h=1e-3",   BENCH_N_BIG, numx_diff_forward(f_x3, 2.0f, 1e-3f, &r));
+    BENCH("diff_central  h=1e-3",   BENCH_N_BIG, numx_diff_central(f_x3, 2.0f, 1e-3f, &r));
+    BENCH("diff_richardson h=1e-3", BENCH_N_BIG, numx_diff_richardson(f_x3, 2.0f, 1e-3f, &r));
+
+    /* ══════════════════════════════════════════════════════════════ */
+    printf("\n[interpolate]\n");
+
+    bench_section("interpolate/interpolate.md");
+    numx_real_t xsi[16], ysi[16], mi[16];
+    for (int i = 0; i < 16; i++) { xsi[i] = (numx_real_t)i * (3.14159f / 15.0f); ysi[i] = xsi[i] * xsi[i]; }
+    BENCH("interp_linear n=16",             BENCH_N_MED,   numx_interp_linear(xsi, ysi, 16, 1.5f, &r));
+    BENCH("interp_spline_cubic n=16",       BENCH_N_MED,   numx_interp_spline_cubic(xsi, ysi, 16, 1.5f, &r));
+    numx_interp_spline_precompute(xsi, ysi, 16, mi);
+    BENCH("interp_spline_eval (precomp)",   BENCH_N_MED,   numx_interp_spline_eval(xsi, ysi, mi, 16, 1.5f, &r));
+    BENCH("interp_spline_precompute n=16",  BENCH_N_MED,   numx_interp_spline_precompute(xsi, ysi, 16, mi));
+    BENCH("interp_chebyshev n=8",           BENCH_N_MED,   numx_interp_chebyshev(f_sq, 8, 0, 3.14f, 1.5f, &r));
+    BENCH("interp_chebyshev n=16",          BENCH_N_SMALL, numx_interp_chebyshev(f_sq, 16, 0, 3.14f, 1.5f, &r));
+
+    /* ══════════════════════════════════════════════════════════════ */
+    printf("\n[poly]\n");
+
+    bench_section("poly/poly.md");
+    numx_real_t cp8[9] = {1, 0, 0, 0, -3, 0, 0, 0, 2}, cp3[4] = {1, -6, 11, -6};
+    numx_real_t pro[3]; numx_size_t pnr;
+    BENCH("poly_eval degree=8",           BENCH_N_BIG,  numx_poly_eval(cp8, 8, 1.5f, &r));
+    BENCH("poly_eval degree=3",           BENCH_N_BIG,  numx_poly_eval(cp3, 3, 2.5f, &r));
+    BENCH("poly_roots degree=3 tol=1e-4", BENCH_N_TINY, numx_poly_roots(cp3, 3, pro, &pnr, 1e-4f));
+
+    /* ══════════════════════════════════════════════════════════════ */
+    printf("\n[ode]\n");
+
+    bench_section("ode/ode.md");
+    numx_real_t yo[1] = {1.0f}, yho[2] = {1.0f, 0.0f}, yor[1], yor2[2];
+    BENCH("ode_rk4  decay   n=1 100-steps",    BENCH_N_SMALL, numx_ode_rk4(ode_decay, 0, yo,  1, 0.01f, 100, yo));
+    BENCH("ode_rk4  harmonic n=2 100-steps",   BENCH_N_SMALL, numx_ode_rk4(ode_harm,  0, yho, 2, 0.01f, 100, yho));
+    BENCH("ode_rk45 decay   n=1 tol=1e-4",     BENCH_N_SMALL, numx_ode_rk45(ode_decay, 0, 1.0f, yo,  1, 1e-4f, yor));
+    BENCH("ode_rk45 harmonic n=2 tol=1e-4",    BENCH_N_SMALL, numx_ode_rk45(ode_harm,  0, 1.0f, yho, 2, 1e-4f, yor2));
+}

--- a/tests/esp32_tests/esp32_tests.c
+++ b/tests/esp32_tests/esp32_tests.c
@@ -1,0 +1,19 @@
+#include "esp32_tests.h"
+#include "tests.h"
+
+void run_all_tests(numxt_ctx_t *ctx)
+{
+    test_linalg(ctx);
+    test_stats(ctx);
+    test_roots(ctx);
+    test_integrate(ctx);
+    test_differentiate(ctx);
+    test_interpolate(ctx);
+    test_poly(ctx);
+    test_ode(ctx);
+    test_signal(ctx);
+    test_fft(ctx);
+    test_autodiff(ctx);
+    test_compressed_sensing(ctx);
+    test_sketch(ctx);
+}

--- a/tests/esp32_tests/include/esp32_tests.h
+++ b/tests/esp32_tests/include/esp32_tests.h
@@ -1,0 +1,104 @@
+#ifndef NUMX_ESP32_TESTS_H
+#define NUMX_ESP32_TESTS_H
+
+/**
+ * @brief  Test execution context.  Declare one on the stack in app_main,
+ *         zero-initialise it, then pass it to every test function.
+ *         No global state — fully reentrant (Rule 4).
+ */
+typedef struct {
+    int pass; /**< Assertions passed. */
+    int fail; /**< Assertions failed. */
+} numxt_ctx_t;
+
+/**
+ * @brief  Run the linear-algebra test suite.
+ * @param[in,out] ctx  Test context accumulating pass/fail counts.
+ */
+void test_linalg(numxt_ctx_t *ctx);
+
+/**
+ * @brief  Run the statistics test suite.
+ * @param[in,out] ctx  Test context accumulating pass/fail counts.
+ */
+void test_stats(numxt_ctx_t *ctx);
+
+/**
+ * @brief  Run the root-finding test suite.
+ * @param[in,out] ctx  Test context accumulating pass/fail counts.
+ */
+void test_roots(numxt_ctx_t *ctx);
+
+/**
+ * @brief  Run the numerical integration test suite.
+ * @param[in,out] ctx  Test context accumulating pass/fail counts.
+ */
+void test_integrate(numxt_ctx_t *ctx);
+
+/**
+ * @brief  Run the numerical differentiation test suite.
+ * @param[in,out] ctx  Test context accumulating pass/fail counts.
+ */
+void test_differentiate(numxt_ctx_t *ctx);
+
+/**
+ * @brief  Run the interpolation test suite.
+ * @param[in,out] ctx  Test context accumulating pass/fail counts.
+ */
+void test_interpolate(numxt_ctx_t *ctx);
+
+/**
+ * @brief  Run the polynomial test suite.
+ * @param[in,out] ctx  Test context accumulating pass/fail counts.
+ */
+void test_poly(numxt_ctx_t *ctx);
+
+/**
+ * @brief  Run the ODE solver test suite.
+ * @param[in,out] ctx  Test context accumulating pass/fail counts.
+ */
+void test_ode(numxt_ctx_t *ctx);
+
+/**
+ * @brief  Run the signal processing test suite.
+ * @param[in,out] ctx  Test context accumulating pass/fail counts.
+ */
+void test_signal(numxt_ctx_t *ctx);
+
+/**
+ * @brief  Run the FFT/IFFT test suite.
+ * @param[in,out] ctx  Test context accumulating pass/fail counts.
+ */
+void test_fft(numxt_ctx_t *ctx);
+
+/**
+ * @brief  Run the automatic differentiation test suite.
+ * @param[in,out] ctx  Test context accumulating pass/fail counts.
+ */
+void test_autodiff(numxt_ctx_t *ctx);
+
+/**
+ * @brief  Run the compressed sensing (OMP/ISTA) test suite.
+ * @param[in,out] ctx  Test context accumulating pass/fail counts.
+ */
+void test_compressed_sensing(numxt_ctx_t *ctx);
+
+/**
+ * @brief  Run the randomized SVD sketch test suite.
+ * @param[in,out] ctx  Test context accumulating pass/fail counts.
+ */
+void test_sketch(numxt_ctx_t *ctx);
+
+/**
+ * @brief  Run all thirteen test suites in sequence.
+ * @param[in,out] ctx  Test context accumulating pass/fail counts.
+ */
+void run_all_tests(numxt_ctx_t *ctx);
+
+/**
+ * @brief  Run the benchmark suite and print timing results to stdout.
+ *         Does not affect the test context.
+ */
+void run_benchmarks(void);
+
+#endif /* NUMX_ESP32_TESTS_H */

--- a/tests/esp32_tests/math_helpers.c
+++ b/tests/esp32_tests/math_helpers.c
@@ -1,0 +1,35 @@
+#include "math_helpers.h"
+#include "numx/numx_types.h"
+
+numx_real_t f_lin(numx_real_t x)   { return x - 2.0f; }
+numx_real_t df_lin(numx_real_t x)  { (void)x; return 1.0f; }
+
+numx_real_t f_quad(numx_real_t x)  { return x*x - 4.0f; }
+numx_real_t df_quad(numx_real_t x) { return 2.0f*x; }
+
+numx_real_t f_cubic(numx_real_t x)  { return x*x*x - x; }
+numx_real_t df_cubic(numx_real_t x) { return 3.0f*x*x - 1.0f; }
+
+numx_real_t f_dbl(numx_real_t x)  { numx_real_t d = x - (numx_real_t)1.0; return d*d; }
+numx_real_t df_dbl(numx_real_t x) { return 2.0f*(x - 1.0f); }
+
+numx_real_t f_one(numx_real_t x)  { (void)x; return 1.0f; }
+numx_real_t f_xsq(numx_real_t x)  { return x*x; }
+numx_real_t f_xcb(numx_real_t x)  { return x*x*x; }
+numx_real_t f_xlin(numx_real_t x) { return x; }
+numx_real_t f_x3(numx_real_t x)   { return x*x*x; }
+numx_real_t f_sq(numx_real_t x)   { return x*x; }
+numx_real_t f_neg_x(numx_real_t x) { return -x; }
+numx_real_t f_c3(numx_real_t x)   { (void)x; return 3.0f; }
+
+numx_status_t ode_decay(numx_real_t t, const numx_real_t *y, numx_size_t n, numx_real_t *d)
+{ (void)t; (void)n; d[0] = -y[0]; return NUMX_OK; }
+
+numx_status_t ode_growth(numx_real_t t, const numx_real_t *y, numx_size_t n, numx_real_t *d)
+{ (void)t; (void)n; d[0] = y[0]; return NUMX_OK; }
+
+numx_status_t ode_harm(numx_real_t t, const numx_real_t *y, numx_size_t n, numx_real_t *d)
+{ (void)t; (void)n; d[0] = y[1]; d[1] = -y[0]; return NUMX_OK; }
+
+numx_status_t ode_err(numx_real_t t, const numx_real_t *y, numx_size_t n, numx_real_t *d)
+{ (void)t; (void)y; (void)n; (void)d; return NUMX_ERR_SINGULAR; }

--- a/tests/esp32_tests/math_helpers.h
+++ b/tests/esp32_tests/math_helpers.h
@@ -1,0 +1,28 @@
+#ifndef NUMX_MATH_HELPERS_H
+#define NUMX_MATH_HELPERS_H
+
+#include "numx/numx_types.h"
+
+numx_real_t f_lin(numx_real_t x);
+numx_real_t df_lin(numx_real_t x);
+numx_real_t f_quad(numx_real_t x);
+numx_real_t df_quad(numx_real_t x);
+numx_real_t f_cubic(numx_real_t x);
+numx_real_t df_cubic(numx_real_t x);
+numx_real_t f_dbl(numx_real_t x);
+numx_real_t df_dbl(numx_real_t x);
+numx_real_t f_one(numx_real_t x);
+numx_real_t f_xsq(numx_real_t x);
+numx_real_t f_xcb(numx_real_t x);
+numx_real_t f_xlin(numx_real_t x);
+numx_real_t f_x3(numx_real_t x);
+numx_real_t f_sq(numx_real_t x);
+numx_real_t f_neg_x(numx_real_t x);
+numx_real_t f_c3(numx_real_t x);
+
+numx_status_t ode_decay(numx_real_t t, const numx_real_t *y, numx_size_t n, numx_real_t *d);
+numx_status_t ode_growth(numx_real_t t, const numx_real_t *y, numx_size_t n, numx_real_t *d);
+numx_status_t ode_harm(numx_real_t t, const numx_real_t *y, numx_size_t n, numx_real_t *d);
+numx_status_t ode_err(numx_real_t t, const numx_real_t *y, numx_size_t n, numx_real_t *d);
+
+#endif /* NUMX_MATH_HELPERS_H */

--- a/tests/esp32_tests/test_autodiff.c
+++ b/tests/esp32_tests/test_autodiff.c
@@ -1,0 +1,287 @@
+#include "test_helpers.h"
+#include "numx/autodiff.h"
+
+/*
+ * numx_ad_tape_t is ~82 KB (4096 nodes × 20 bytes).
+ * Declared static so it lives in .bss instead of the task stack.
+ */
+static numx_ad_tape_t s_tape;
+
+void test_autodiff(numxt_ctx_t *ctx)
+{
+    /* ── forward-mode: constructors ──────────────────────────────── */
+    suite("autodiff / dual_const_var");
+    {
+        numx_dual_t c = numx_dual_const(5.0f);
+        chk_f(ctx, "dual_const re=5", c.re, 5.0f, 1e-5f);
+        chk_f(ctx, "dual_const du=0", c.du, 0.0f, 1e-5f);
+
+        numx_dual_t v = numx_dual_var(3.0f);
+        chk_f(ctx, "dual_var re=3",   v.re, 3.0f, 1e-5f);
+        chk_f(ctx, "dual_var du=1",   v.du, 1.0f, 1e-5f);
+    }
+
+    /* ── forward-mode: arithmetic ────────────────────────────────── */
+    suite("autodiff / dual_arith");
+    {
+        numx_dual_t x, c3, r;
+
+        /* d/dx(x+3) at x=2: re=5, du=1 */
+        x  = numx_dual_var(2.0f);
+        c3 = numx_dual_const(3.0f);
+        r  = numx_dual_add(x, c3);
+        chk_f(ctx, "dual_add re=5",   r.re, 5.0f,       1e-5f);
+        chk_f(ctx, "dual_add du=1",   r.du, 1.0f,       1e-5f);
+
+        /* d/dx(x-3) at x=5: re=2, du=1 */
+        x = numx_dual_var(5.0f);
+        r = numx_dual_sub(x, c3);
+        chk_f(ctx, "dual_sub re=2",   r.re, 2.0f,       1e-5f);
+        chk_f(ctx, "dual_sub du=1",   r.du, 1.0f,       1e-5f);
+
+        /* d/dx(x^2) at x=3: re=9, du=6 */
+        x = numx_dual_var(3.0f);
+        r = numx_dual_mul(x, x);
+        chk_f(ctx, "dual_mul x^2 re=9", r.re, 9.0f,     1e-5f);
+        chk_f(ctx, "dual_mul x^2 du=6", r.du, 6.0f,     1e-5f);
+
+        /* d/dx(x/3) at x=6: re=2, du=1/3 */
+        x = numx_dual_var(6.0f);
+        r = numx_dual_div(x, c3);
+        chk_f(ctx, "dual_div re=2",     r.re, 2.0f,     1e-5f);
+        chk_f(ctx, "dual_div du=1/3",   r.du, 1.0f/3.0f,1e-5f);
+
+        /* d/dx(-x) at x=3: re=-3, du=-1 */
+        x = numx_dual_var(3.0f);
+        r = numx_dual_neg(x);
+        chk_f(ctx, "dual_neg re=-3",    r.re, -3.0f,    1e-5f);
+        chk_f(ctx, "dual_neg du=-1",    r.du, -1.0f,    1e-5f);
+    }
+
+    /* ── forward-mode: transcendentals ──────────────────────────── */
+    suite("autodiff / dual_transcendental");
+    {
+        numx_dual_t x, r;
+
+        /* d/dx sin(x) at x=0: re=0, du=cos(0)=1 */
+        x = numx_dual_var(0.0f);
+        r = numx_dual_sin(x);
+        chk_f(ctx, "dual_sin re=0", r.re, 0.0f, 1e-3f);
+        chk_f(ctx, "dual_sin du=1", r.du, 1.0f, 1e-3f);
+
+        /* d/dx cos(x) at x=0: re=1, du=-sin(0)=0 */
+        r = numx_dual_cos(x);
+        chk_f(ctx, "dual_cos re=1", r.re, 1.0f, 1e-3f);
+        chk_f(ctx, "dual_cos du=0", r.du, 0.0f, 1e-3f);
+
+        /* d/dx exp(x) at x=0: re=1, du=1 */
+        r = numx_dual_exp(x);
+        chk_f(ctx, "dual_exp re=1", r.re, 1.0f, 1e-3f);
+        chk_f(ctx, "dual_exp du=1", r.du, 1.0f, 1e-3f);
+
+        /* d/dx log(x) at x=1: re=0, du=1 */
+        x = numx_dual_var(1.0f);
+        r = numx_dual_log(x);
+        chk_f(ctx, "dual_log re=0", r.re, 0.0f, 1e-3f);
+        chk_f(ctx, "dual_log du=1", r.du, 1.0f, 1e-3f);
+
+        /* d/dx sqrt(x) at x=4: re=2, du=0.25 */
+        x = numx_dual_var(4.0f);
+        r = numx_dual_sqrt(x);
+        chk_f(ctx, "dual_sqrt re=2",    r.re, 2.0f,  1e-3f);
+        chk_f(ctx, "dual_sqrt du=0.25", r.du, 0.25f, 1e-3f);
+    }
+
+    /* ── forward-mode: chain rule ────────────────────────────────── */
+    suite("autodiff / dual_chain");
+    {
+        /* d/dx(x^2+5) at x=3: re=14, du=6 */
+        numx_dual_t x  = numx_dual_var(3.0f);
+        numx_dual_t x2 = numx_dual_mul(x, x);
+        numx_dual_t c5 = numx_dual_const(5.0f);
+        numx_dual_t r  = numx_dual_add(x2, c5);
+        chk_f(ctx, "dual_chain quadratic re=14", r.re, 14.0f, 1e-5f);
+        chk_f(ctx, "dual_chain quadratic du=6",  r.du,  6.0f, 1e-5f);
+    }
+
+    /* ── forward-mode: degenerate inputs ─────────────────────────── */
+    suite("autodiff / dual_degenerate");
+    {
+        numx_dual_t r;
+
+        /* div by zero → {0,0} */
+        r = numx_dual_div(numx_dual_var(1.0f), numx_dual_const(0.0f));
+        chk_f(ctx, "dual_div/0 re=0", r.re, 0.0f, 1e-6f);
+        chk_f(ctx, "dual_div/0 du=0", r.du, 0.0f, 1e-6f);
+
+        /* log(0) → {0,0} */
+        r = numx_dual_log(numx_dual_const(0.0f));
+        chk_f(ctx, "dual_log(0) re=0", r.re, 0.0f, 1e-6f);
+
+        /* sqrt(-4) → {0,0} */
+        r = numx_dual_sqrt(numx_dual_var(-4.0f));
+        chk_f(ctx, "dual_sqrt(-4) re=0", r.re, 0.0f, 1e-6f);
+    }
+
+    /* ── reverse-mode: tape init and var ─────────────────────────── */
+    suite("autodiff / tape_init");
+    {
+        numx_size_t ix;
+        chk_rc(ctx, "ad_init rc",       numx_ad_init(&s_tape),          NUMX_OK);
+        chk_true(ctx, "ad_init len=0",  s_tape.len == 0);
+
+        chk_rc(ctx, "ad_var rc",        numx_ad_var(&s_tape, 5.0f, &ix), NUMX_OK);
+        chk_true(ctx, "ad_var idx=0",   ix == 0);
+        chk_f  (ctx, "ad_var val=5",    numx_ad_val(&s_tape, ix), 5.0f, 1e-5f);
+
+        chk_rc(ctx, "ad_init null",     numx_ad_init(NULL),              NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "ad_var null-tape", numx_ad_var(NULL, 1.0f, &ix),    NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "ad_var null-out",  numx_ad_var(&s_tape, 1.0f, NULL),NUMX_ERR_NULL_PTR);
+    }
+
+    /* ── reverse-mode: addition and subtraction ──────────────────── */
+    suite("autodiff / tape_add_sub");
+    {
+        numx_size_t xi, yi, zi;
+
+        /* z = x + y at (3,4): val=7, dz/dx=1, dz/dy=1 */
+        numx_ad_init(&s_tape);
+        numx_ad_var(&s_tape, 3.0f, &xi);
+        numx_ad_var(&s_tape, 4.0f, &yi);
+        chk_rc(ctx, "ad_add rc",         numx_ad_add(&s_tape, xi, yi, &zi), NUMX_OK);
+        chk_rc(ctx, "ad_add backward rc",numx_ad_backward(&s_tape, zi),      NUMX_OK);
+        chk_f (ctx, "ad_add val=7",      numx_ad_val(&s_tape, zi),   7.0f, 1e-5f);
+        chk_f (ctx, "ad_add dz/dx=1",   numx_ad_grad(&s_tape, xi),  1.0f, 1e-5f);
+        chk_f (ctx, "ad_add dz/dy=1",   numx_ad_grad(&s_tape, yi),  1.0f, 1e-5f);
+
+        /* z = x - y at (5,2): dz/dx=1, dz/dy=-1 */
+        numx_ad_init(&s_tape);
+        numx_ad_var(&s_tape, 5.0f, &xi);
+        numx_ad_var(&s_tape, 2.0f, &yi);
+        numx_ad_sub(&s_tape, xi, yi, &zi);
+        numx_ad_backward(&s_tape, zi);
+        chk_f(ctx, "ad_sub dz/dx=1",   numx_ad_grad(&s_tape, xi),  1.0f, 1e-5f);
+        chk_f(ctx, "ad_sub dz/dy=-1",  numx_ad_grad(&s_tape, yi), -1.0f, 1e-5f);
+    }
+
+    /* ── reverse-mode: multiplication and division ───────────────── */
+    suite("autodiff / tape_mul_div");
+    {
+        numx_size_t xi, yi, zi;
+
+        /* z = x*y at (3,4): val=12, dz/dx=4, dz/dy=3 */
+        numx_ad_init(&s_tape);
+        numx_ad_var(&s_tape, 3.0f, &xi);
+        numx_ad_var(&s_tape, 4.0f, &yi);
+        numx_ad_mul(&s_tape, xi, yi, &zi);
+        numx_ad_backward(&s_tape, zi);
+        chk_f(ctx, "ad_mul val=12",   numx_ad_val(&s_tape,  zi), 12.0f, 1e-5f);
+        chk_f(ctx, "ad_mul dz/dx=4", numx_ad_grad(&s_tape, xi),  4.0f, 1e-5f);
+        chk_f(ctx, "ad_mul dz/dy=3", numx_ad_grad(&s_tape, yi),  3.0f, 1e-5f);
+
+        /* z = x/y at (6,2): dz/dx=0.5, dz/dy=-1.5 */
+        numx_ad_init(&s_tape);
+        numx_ad_var(&s_tape, 6.0f, &xi);
+        numx_ad_var(&s_tape, 2.0f, &yi);
+        numx_ad_div(&s_tape, xi, yi, &zi);
+        numx_ad_backward(&s_tape, zi);
+        chk_f(ctx, "ad_div dz/dx=0.5",  numx_ad_grad(&s_tape, xi),  0.5f, 1e-5f);
+        chk_f(ctx, "ad_div dz/dy=-1.5", numx_ad_grad(&s_tape, yi), -1.5f, 1e-5f);
+
+        /* z = -x at x=5: val=-5, dz/dx=-1 */
+        numx_ad_init(&s_tape);
+        numx_ad_var(&s_tape, 5.0f, &xi);
+        numx_ad_neg(&s_tape, xi, &zi);
+        numx_ad_backward(&s_tape, zi);
+        chk_f(ctx, "ad_neg val=-5",   numx_ad_val(&s_tape,  zi), -5.0f, 1e-5f);
+        chk_f(ctx, "ad_neg dz/dx=-1", numx_ad_grad(&s_tape, xi), -1.0f, 1e-5f);
+    }
+
+    /* ── reverse-mode: transcendentals ──────────────────────────── */
+    suite("autodiff / tape_transcendental");
+    {
+        numx_size_t xi, zi;
+
+        /* sin(0): grad=cos(0)=1 */
+        numx_ad_init(&s_tape);
+        numx_ad_var(&s_tape, 0.0f, &xi);
+        numx_ad_sin(&s_tape, xi, &zi);
+        numx_ad_backward(&s_tape, zi);
+        chk_f(ctx, "ad_sin grad=1",    numx_ad_grad(&s_tape, xi),  1.0f, 1e-3f);
+
+        /* cos(0): grad=-sin(0)=0 */
+        numx_ad_init(&s_tape);
+        numx_ad_var(&s_tape, 0.0f, &xi);
+        numx_ad_cos(&s_tape, xi, &zi);
+        numx_ad_backward(&s_tape, zi);
+        chk_f(ctx, "ad_cos grad=0",    numx_ad_grad(&s_tape, xi),  0.0f, 1e-3f);
+
+        /* exp(0): val=1, grad=1 */
+        numx_ad_init(&s_tape);
+        numx_ad_var(&s_tape, 0.0f, &xi);
+        numx_ad_exp(&s_tape, xi, &zi);
+        numx_ad_backward(&s_tape, zi);
+        chk_f(ctx, "ad_exp val=1",     numx_ad_val(&s_tape,  zi),  1.0f, 1e-3f);
+        chk_f(ctx, "ad_exp grad=1",    numx_ad_grad(&s_tape, xi),  1.0f, 1e-3f);
+
+        /* log(1): val=0, grad=1 */
+        numx_ad_init(&s_tape);
+        numx_ad_var(&s_tape, 1.0f, &xi);
+        numx_ad_log(&s_tape, xi, &zi);
+        numx_ad_backward(&s_tape, zi);
+        chk_f(ctx, "ad_log val=0",     numx_ad_val(&s_tape,  zi),  0.0f, 1e-3f);
+        chk_f(ctx, "ad_log grad=1",    numx_ad_grad(&s_tape, xi),  1.0f, 1e-3f);
+
+        /* sqrt(4): val=2, grad=0.25 */
+        numx_ad_init(&s_tape);
+        numx_ad_var(&s_tape, 4.0f, &xi);
+        numx_ad_sqrt(&s_tape, xi, &zi);
+        numx_ad_backward(&s_tape, zi);
+        chk_f(ctx, "ad_sqrt val=2",    numx_ad_val(&s_tape,  zi),  2.0f,  1e-3f);
+        chk_f(ctx, "ad_sqrt grad=0.25",numx_ad_grad(&s_tape, xi),  0.25f, 1e-3f);
+    }
+
+    /* ── reverse-mode: multi-variable gradient ───────────────────── */
+    suite("autodiff / tape_multivar");
+    {
+        /* z = x^2 + y^2 at (3,4): val=25, dz/dx=6, dz/dy=8 */
+        numx_size_t xi, yi, x2i, y2i, zi;
+        numx_ad_init(&s_tape);
+        numx_ad_var(&s_tape, 3.0f, &xi);
+        numx_ad_var(&s_tape, 4.0f, &yi);
+        numx_ad_mul(&s_tape, xi, xi, &x2i);
+        numx_ad_mul(&s_tape, yi, yi, &y2i);
+        numx_ad_add(&s_tape, x2i, y2i, &zi);
+        numx_ad_backward(&s_tape, zi);
+        chk_f(ctx, "tape_quad val=25",  numx_ad_val(&s_tape,  zi), 25.0f, 1e-4f);
+        chk_f(ctx, "tape_quad dz/dx=6", numx_ad_grad(&s_tape, xi),  6.0f, 1e-4f);
+        chk_f(ctx, "tape_quad dz/dy=8", numx_ad_grad(&s_tape, yi),  8.0f, 1e-4f);
+    }
+
+    /* ── reverse-mode: error cases ───────────────────────────────── */
+    suite("autodiff / tape_errors");
+    {
+        numx_size_t xi, yi, zi;
+        numx_ad_init(&s_tape);
+        numx_ad_var(&s_tape, 1.0f, &xi);
+
+        chk_rc(ctx, "backward null",   numx_ad_backward(NULL, 0),           NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "backward oob",    numx_ad_backward(&s_tape, 999),       NUMX_ERR_INVALID_ARG);
+        chk_rc(ctx, "ad_add oob-b",    numx_ad_add(&s_tape, 0, 999, &zi),   NUMX_ERR_INVALID_ARG);
+        chk_rc(ctx, "ad_neg oob",      numx_ad_neg(&s_tape, 999, &zi),       NUMX_ERR_INVALID_ARG);
+
+        /* div by zero on tape */
+        numx_ad_var(&s_tape, 0.0f, &yi);
+        chk_rc(ctx, "ad_div/0",        numx_ad_div(&s_tape, xi, yi, &zi),   NUMX_ERR_SINGULAR);
+
+        /* log of zero/negative */
+        numx_ad_init(&s_tape);
+        numx_ad_var(&s_tape, 0.0f, &xi);
+        chk_rc(ctx, "ad_log(0)",       numx_ad_log(&s_tape, xi, &zi),        NUMX_ERR_INVALID_ARG);
+
+        /* sqrt of negative */
+        numx_ad_init(&s_tape);
+        numx_ad_var(&s_tape, -1.0f, &xi);
+        chk_rc(ctx, "ad_sqrt(-1)",     numx_ad_sqrt(&s_tape, xi, &zi),       NUMX_ERR_INVALID_ARG);
+    }
+}

--- a/tests/esp32_tests/test_compressed_sensing.c
+++ b/tests/esp32_tests/test_compressed_sensing.c
@@ -1,0 +1,106 @@
+#include "test_helpers.h"
+#include "numx/compressed_sensing.h"
+
+/*
+ * Stack note: numx_cs_omp uses ~9 KB of local variables (configurable via
+ * NUMX_MAX_CS_MEASUREMENTS / NUMX_MAX_CS_SPARSITY in numx_config.h).
+ * Ensure CONFIG_ESP_MAIN_TASK_STACK_SIZE >= 16384 in sdkconfig.
+ */
+
+void test_compressed_sensing(numxt_ctx_t *ctx)
+{
+    /* ── spectral_norm ───────────────────────────────────────────── */
+    suite("cs / spectral_norm");
+    {
+        /* 3×3 identity: σ_max = 1 */
+        numx_real_t I3[9] = {1,0,0, 0,1,0, 0,0,1};
+        numx_real_t sigma;
+        chk_rc(ctx, "spectral_norm I3 rc",
+               numx_cs_spectral_norm(I3, 3, 3, 32, &sigma), NUMX_OK);
+        chk_f (ctx, "spectral_norm I3=1.0", sigma, 1.0f, 5e-3f);
+
+        /* 3×3 diagonal [3,1,1]: σ_max = 3 */
+        numx_real_t D3[9] = {3,0,0, 0,1,0, 0,0,1};
+        numx_cs_spectral_norm(D3, 3, 3, 64, &sigma);
+        chk_f (ctx, "spectral_norm D3=3.0", sigma, 3.0f, 5e-2f);
+
+        chk_rc(ctx, "spectral_norm null-A",
+               numx_cs_spectral_norm(NULL, 3, 3, 32, &sigma), NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "spectral_norm null-out",
+               numx_cs_spectral_norm(I3, 3, 3, 32, NULL),     NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "spectral_norm m=0",
+               numx_cs_spectral_norm(I3, 0, 3, 32, &sigma),   NUMX_ERR_INVALID_ARG);
+        chk_rc(ctx, "spectral_norm n=0",
+               numx_cs_spectral_norm(I3, 3, 0, 32, &sigma),   NUMX_ERR_INVALID_ARG);
+    }
+
+    /* ── omp ─────────────────────────────────────────────────────── */
+    suite("cs / omp");
+    {
+        /*
+         * A = I_4, y = [3,0,0,0], k=1.
+         * OMP should select column 0 and recover x = [3,0,0,0].
+         */
+        numx_real_t A[16] = {1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1};
+        numx_real_t y[4]  = {3,0,0,0};
+        numx_real_t x[4]  = {0,0,0,0};
+
+        chk_rc(ctx, "omp identity rc",
+               numx_cs_omp(A, y, 4, 4, 1, x), NUMX_OK);
+        chk_f (ctx, "omp identity x[0]=3", x[0], 3.0f, 5e-3f);
+        chk_f (ctx, "omp identity x[1]=0", x[1], 0.0f, 5e-3f);
+        chk_f (ctx, "omp identity x[2]=0", x[2], 0.0f, 5e-3f);
+        chk_f (ctx, "omp identity x[3]=0", x[3], 0.0f, 5e-3f);
+
+        /* 2-sparse recovery: y = [2,0,5,0], k=2 → x=[2,0,5,0] */
+        numx_real_t y2[4] = {2,0,5,0}, x2[4] = {0,0,0,0};
+        numx_cs_omp(A, y2, 4, 4, 2, x2);
+        chk_f (ctx, "omp 2-sparse x[0]=2", x2[0], 2.0f, 5e-3f);
+        chk_f (ctx, "omp 2-sparse x[2]=5", x2[2], 5.0f, 5e-3f);
+
+        chk_rc(ctx, "omp null-A",
+               numx_cs_omp(NULL, y, 4, 4, 1, x),  NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "omp null-y",
+               numx_cs_omp(A, NULL, 4, 4, 1, x),  NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "omp null-x",
+               numx_cs_omp(A, y, 4, 4, 1, NULL),   NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "omp m=0",
+               numx_cs_omp(A, y, 0, 4, 1, x),      NUMX_ERR_INVALID_ARG);
+        chk_rc(ctx, "omp n=0",
+               numx_cs_omp(A, y, 4, 0, 1, x),      NUMX_ERR_INVALID_ARG);
+        chk_rc(ctx, "omp k=0",
+               numx_cs_omp(A, y, 4, 4, 0, x),      NUMX_ERR_INVALID_ARG);
+    }
+
+    /* ── ista ────────────────────────────────────────────────────── */
+    suite("cs / ista");
+    {
+        /*
+         * A = I_4, y = [5,0,0,0], lambda=0.5, step=0.9 (< 1/σ_max^2 = 1).
+         * LASSO solution: x* = soft_threshold(y, lambda) = [4.5,0,0,0].
+         */
+        numx_real_t A[16] = {1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1};
+        numx_real_t y[4]  = {5,0,0,0};
+        numx_real_t x[4]  = {0,0,0,0};
+
+        chk_rc(ctx, "ista identity rc",
+               numx_cs_ista(A, y, 4, 4, 0.5f, 0.9f, 1000, x), NUMX_OK);
+        chk_f (ctx, "ista identity x[0]≈4.5", x[0], 4.5f, 0.05f);
+        chk_f (ctx, "ista identity x[1]=0",   x[1], 0.0f, 1e-3f);
+        chk_f (ctx, "ista identity x[2]=0",   x[2], 0.0f, 1e-3f);
+
+        numx_real_t xb[4] = {0};
+        chk_rc(ctx, "ista null-A",
+               numx_cs_ista(NULL, y, 4, 4, 0.5f, 0.9f, 100, xb), NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "ista null-y",
+               numx_cs_ista(A, NULL, 4, 4, 0.5f, 0.9f, 100, xb), NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "ista null-x",
+               numx_cs_ista(A, y, 4, 4, 0.5f, 0.9f, 100, NULL),  NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "ista step=0",
+               numx_cs_ista(A, y, 4, 4, 0.5f, 0.0f, 100, xb),    NUMX_ERR_INVALID_ARG);
+        chk_rc(ctx, "ista step<0",
+               numx_cs_ista(A, y, 4, 4, 0.5f, -0.1f, 100, xb),   NUMX_ERR_INVALID_ARG);
+        chk_rc(ctx, "ista lambda<0",
+               numx_cs_ista(A, y, 4, 4, -0.1f, 0.9f, 100, xb),   NUMX_ERR_INVALID_ARG);
+    }
+}

--- a/tests/esp32_tests/test_differentiate.c
+++ b/tests/esp32_tests/test_differentiate.c
@@ -1,0 +1,83 @@
+#include "test_helpers.h"
+#include "math_helpers.h"
+#include "numx/differentiate.h"
+
+void test_differentiate(numxt_ctx_t *ctx)
+{
+    numx_real_t r;
+
+    suite("diff / forward");
+    {
+        chk_rc(ctx, "fwd rc", numx_diff_forward(f_x3,3.0f,1e-3f,&r), NUMX_OK);
+        chk_f (ctx,"fwd x^3 at 3 = 27",   r, 27.0f, 1e-2f);
+
+        numx_diff_forward(f_x3,2.0f,1e-3f,&r);
+        chk_f (ctx,"fwd x^3 at 2 = 12",   r, 12.0f, 1e-2f);
+
+        numx_diff_forward(f_one,5.0f,1e-3f,&r);
+        chk_f (ctx,"fwd const = 0",       r, 0.0f,  1e-5f);
+
+        numx_diff_forward(f_xlin,5.0f,1e-3f,&r);
+        chk_f (ctx,"fwd linear = 1",      r, 1.0f,  1e-2f);
+
+        numx_diff_forward(f_xsq,3.0f,1e-3f,&r);
+        chk_f (ctx,"fwd x^2 at 3 = 6",   r, 6.0f,  1e-2f);
+
+        chk_rc(ctx, "fwd null-f",   numx_diff_forward(NULL,1.0f,1e-3f,&r),    NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "fwd null-out", numx_diff_forward(f_x3,1.0f,1e-3f,NULL),  NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "fwd h=0",      numx_diff_forward(f_x3,1.0f,0.0f,&r),     NUMX_ERR_INVALID_ARG);
+        chk_rc(ctx, "fwd h<0",      numx_diff_forward(f_x3,1.0f,-1e-3f,&r),   NUMX_ERR_INVALID_ARG);
+    }
+
+    suite("diff / central");
+    {
+        numx_diff_central(f_x3,3.0f,1e-3f,&r);
+        chk_f (ctx,"central x^3 at 3 = 27", r, 27.0f, 1e-2f);
+
+        numx_diff_central(f_xsq,-2.0f,1e-3f,&r);
+        chk_f (ctx,"central x^2 at -2 = -4",r,-4.0f,  1e-3f);
+
+        numx_diff_central(f_one,5.0f,1e-3f,&r);
+        chk_f (ctx,"central const = 0",      r, 0.0f,  1e-5f);
+
+        numx_diff_central(f_xlin,1.0f,1e-3f,&r);
+        chk_f (ctx,"central linear = 1",     r, 1.0f,  1e-3f);
+
+        numx_diff_central(f_xsq,3.0f,1e-3f,&r);
+        chk_f (ctx,"central x^2 at 3 = 6",  r, 6.0f,  1e-3f);
+
+        numx_diff_central(f_xcb,2.0f,1e-3f,&r);
+        chk_f (ctx,"central x^3 at 2 = 12", r, 12.0f, 1e-2f);
+
+        chk_rc(ctx, "central null-f",   numx_diff_central(NULL,1.0f,1e-3f,&r),   NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "central null-out", numx_diff_central(f_x3,1.0f,1e-3f,NULL), NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "central h=0",      numx_diff_central(f_x3,1.0f,0.0f,&r),    NUMX_ERR_INVALID_ARG);
+        chk_rc(ctx, "central h<0",      numx_diff_central(f_x3,1.0f,-1e-3f,&r),  NUMX_ERR_INVALID_ARG);
+    }
+
+    suite("diff / richardson");
+    {
+        numx_diff_richardson(f_x3,3.0f,1e-3f,&r);
+        chk_f (ctx,"rich x^3 at 3 = 27", r, 27.0f, 1e-2f);
+
+        numx_diff_richardson(f_x3,2.0f,1e-3f,&r);
+        chk_f (ctx,"rich x^3 at 2 = 12", r, 12.0f, 1e-2f);
+
+        numx_real_t rc2, rr2;
+        numx_diff_central(f_xcb,2.0f,0.1f,&rc2);
+        numx_diff_richardson(f_xcb,2.0f,0.1f,&rr2);
+        chk_true(ctx, "rich more accurate than central (large h)",
+                  numxt_absf(rr2-12.0f) < numxt_absf(rc2-12.0f));
+
+        numx_diff_richardson(f_xsq,3.0f,1e-3f,&r);
+        chk_f (ctx,"rich x^2 at 3 = 6",  r, 6.0f,  1e-3f);
+
+        numx_diff_richardson(f_one,5.0f,1e-3f,&r);
+        chk_f (ctx,"rich const = 0",      r, 0.0f,  1e-5f);
+
+        chk_rc(ctx, "rich null-f",   numx_diff_richardson(NULL,1.0f,1e-3f,&r),   NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "rich null-out", numx_diff_richardson(f_x3,1.0f,1e-3f,NULL), NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "rich h=0",      numx_diff_richardson(f_x3,1.0f,0.0f,&r),    NUMX_ERR_INVALID_ARG);
+        chk_rc(ctx, "rich h<0",      numx_diff_richardson(f_x3,1.0f,-1e-3f,&r),  NUMX_ERR_INVALID_ARG);
+    }
+}

--- a/tests/esp32_tests/test_fft.c
+++ b/tests/esp32_tests/test_fft.c
@@ -1,0 +1,109 @@
+#include "test_helpers.h"
+#include "numx/fft.h"
+
+/*
+ * Interleaved complex layout: inout = [re0,im0, re1,im1, ...]
+ * Lengths below refer to the number of complex samples N, so the buffer
+ * is always 2*N floats.
+ */
+
+void test_fft(numxt_ctx_t *ctx)
+{
+    /* ── fft_f32: DC input ───────────────────────────────────────── */
+    suite("fft / f32_dc");
+    {
+        /* N=8, all re=1 im=0 → X[0].re=8, rest≈0 */
+        numx_real_t buf[16] = {
+            1,0, 1,0, 1,0, 1,0,
+            1,0, 1,0, 1,0, 1,0
+        };
+        chk_rc(ctx, "fft_f32 dc n=8 rc",    numx_fft_f32(buf, 8), NUMX_OK);
+        chk_f (ctx, "fft_f32 dc X[0].re=8", buf[0],  8.0f, 1e-3f);
+        chk_f (ctx, "fft_f32 dc X[0].im=0", buf[1],  0.0f, 1e-3f);
+        chk_f (ctx, "fft_f32 dc X[1].re≈0", buf[2],  0.0f, 1e-3f);
+        chk_f (ctx, "fft_f32 dc X[4].re≈0", buf[8],  0.0f, 1e-3f);
+    }
+
+    /* ── fft_f32: unit impulse → flat spectrum ───────────────────── */
+    suite("fft / f32_impulse");
+    {
+        /* N=4, x[0]=1 rest=0 → all bins re=1, im=0 */
+        numx_real_t buf[8] = {1,0, 0,0, 0,0, 0,0};
+        chk_rc(ctx, "fft_f32 impulse rc",     numx_fft_f32(buf, 4), NUMX_OK);
+        chk_f (ctx, "fft_f32 impulse X[0]=1", buf[0], 1.0f, 1e-4f);
+        chk_f (ctx, "fft_f32 impulse X[1]=1", buf[2], 1.0f, 1e-4f);
+        chk_f (ctx, "fft_f32 impulse X[2]=1", buf[4], 1.0f, 1e-4f);
+        chk_f (ctx, "fft_f32 impulse X[3]=1", buf[6], 1.0f, 1e-4f);
+    }
+
+    /* ── FFT/IFFT round-trip ─────────────────────────────────────── */
+    suite("fft / f32_roundtrip");
+    {
+        /* IFFT(FFT(x)) == x for arbitrary real signal */
+        numx_real_t orig[8] = {3,0, 1,0, 4,0, 1,0};
+        numx_real_t buf[8];
+        int i;
+        for (i = 0; i < 8; i++) buf[i] = orig[i];
+        numx_fft_f32(buf, 4);
+        chk_rc(ctx, "ifft_f32 roundtrip rc", numx_ifft_f32(buf, 4), NUMX_OK);
+        chk_f (ctx, "roundtrip re[0]",        buf[0], orig[0], 1e-3f);
+        chk_f (ctx, "roundtrip re[1]",        buf[2], orig[2], 1e-3f);
+        chk_f (ctx, "roundtrip re[2]",        buf[4], orig[4], 1e-3f);
+        chk_f (ctx, "roundtrip re[3]",        buf[6], orig[6], 1e-3f);
+    }
+
+    /* ── fft_magnitude ───────────────────────────────────────────── */
+    suite("fft / magnitude");
+    {
+        /* DC input N=4: after FFT, X[0]=4; mag[0]=4, mag[1..2]≈0 */
+        numx_real_t buf[8] = {1,0, 1,0, 1,0, 1,0};
+        numx_real_t mag[3];
+        numx_fft_f32(buf, 4);
+        chk_rc(ctx, "magnitude dc rc",        numx_fft_magnitude(buf, 4, mag), NUMX_OK);
+        chk_f (ctx, "magnitude dc mag[0]=4",  mag[0], 4.0f, 1e-3f);
+        chk_f (ctx, "magnitude dc mag[1]≈0",  mag[1], 0.0f, 1e-3f);
+        chk_f (ctx, "magnitude dc mag[2]≈0",  mag[2], 0.0f, 1e-3f);
+
+        chk_rc(ctx, "magnitude null-fft",     numx_fft_magnitude(NULL, 4, mag), NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "magnitude null-mag",     numx_fft_magnitude(buf,  4, NULL),NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "magnitude n=1",          numx_fft_magnitude(buf,  1, mag), NUMX_ERR_INVALID_ARG);
+        chk_rc(ctx, "magnitude n=3 (non-pow2)",numx_fft_magnitude(buf, 3, mag), NUMX_ERR_INVALID_ARG);
+    }
+
+    /* ── fft_q15 ─────────────────────────────────────────────────── */
+    suite("fft / q15");
+    {
+        /*
+         * N=2, DC input [A,0, A,0] in Q15.
+         * One butterfly stage with >>1 shift:
+         *   X[0] = (A+A)>>1 = A,  X[1] = (A-A)>>1 = 0
+         */
+        numx_q15_t buf[4] = {0x4000, 0, 0x4000, 0};
+        chk_rc(ctx, "fft_q15 dc n=2 rc",      numx_fft_q15(buf, 2), NUMX_OK);
+        chk_true(ctx, "fft_q15 dc X[0].re>0", buf[0] > 0);
+        chk_true(ctx, "fft_q15 dc X[1].re=0", buf[2] == 0);
+
+        /* impulse [0x7FFF,0, 0,0] N=2: X[0]=0x7FFF>>1, X[1]=0x7FFF>>1 */
+        numx_q15_t ibuf[4] = {0x7FFF, 0, 0, 0};
+        numx_fft_q15(ibuf, 2);
+        chk_true(ctx, "fft_q15 impulse X[0]>0", ibuf[0] > 0);
+        chk_true(ctx, "fft_q15 impulse X[1]>0", ibuf[2] > 0);
+
+        chk_rc(ctx, "fft_q15 null",           numx_fft_q15(NULL, 4),    NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "fft_q15 n=0",            numx_fft_q15(buf,  0),    NUMX_ERR_INVALID_ARG);
+        chk_rc(ctx, "fft_q15 n=3 (non-pow2)", numx_fft_q15(buf,  3),    NUMX_ERR_INVALID_ARG);
+    }
+
+    /* ── fft_f32 / ifft_f32: error cases ────────────────────────── */
+    suite("fft / f32_errors");
+    {
+        numx_real_t buf[8] = {1,0, 0,0, 0,0, 0,0};
+        chk_rc(ctx, "fft_f32 null",        numx_fft_f32(NULL, 4),                   NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "fft_f32 n=0",         numx_fft_f32(buf,  0),                   NUMX_ERR_INVALID_ARG);
+        chk_rc(ctx, "fft_f32 n=3",         numx_fft_f32(buf,  3),                   NUMX_ERR_INVALID_ARG);
+        chk_rc(ctx, "fft_f32 n>max",       numx_fft_f32(buf,  NUMX_MAX_FFT_SIZE*2), NUMX_ERR_INVALID_ARG);
+        chk_rc(ctx, "ifft_f32 null",       numx_ifft_f32(NULL, 4),                  NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "ifft_f32 n=0",        numx_ifft_f32(buf,  0),                  NUMX_ERR_INVALID_ARG);
+        chk_rc(ctx, "ifft_f32 n=3",        numx_ifft_f32(buf,  3),                  NUMX_ERR_INVALID_ARG);
+    }
+}

--- a/tests/esp32_tests/test_helpers.c
+++ b/tests/esp32_tests/test_helpers.c
@@ -1,0 +1,45 @@
+#include <stdio.h>
+#include "test_helpers.h"
+
+void suite(const char *name)
+{
+    printf("\n── %s ─────────────────────────────────────\n", name);
+}
+
+void chk_f(numxt_ctx_t *ctx, const char *label,
+           numx_real_t got, numx_real_t ref, numx_real_t tol)
+{
+    numx_real_t err = numxt_absf(got - ref);
+    if (err <= tol) {
+        printf("  PASS  %-48s  out=%.7f  err=%.2e\n", label, (double)got, (double)err);
+        ctx->pass++;
+    } else {
+        printf("  FAIL  %-48s  out=%.7f  ref=%.7f  err=%.2e  tol=%.2e\n",
+               label, (double)got, (double)ref, (double)err, (double)tol);
+        ctx->fail++;
+    }
+}
+
+void chk_rc(numxt_ctx_t *ctx, const char *label,
+            numx_status_t got, numx_status_t exp)
+{
+    if (got == exp) {
+        printf("  PASS  %-52s rc=%d\n", label, (int)got);
+        ctx->pass++;
+    } else {
+        printf("  FAIL  %-52s got rc=%d expected=%d\n",
+               label, (int)got, (int)exp);
+        ctx->fail++;
+    }
+}
+
+void chk_true(numxt_ctx_t *ctx, const char *label, int cond)
+{
+    if (cond) {
+        printf("  PASS  %-52s\n", label);
+        ctx->pass++;
+    } else {
+        printf("  FAIL  %-52s (condition false)\n", label);
+        ctx->fail++;
+    }
+}

--- a/tests/esp32_tests/test_helpers.h
+++ b/tests/esp32_tests/test_helpers.h
@@ -1,0 +1,52 @@
+#ifndef NUMX_TEST_HELPERS_H
+#define NUMX_TEST_HELPERS_H
+
+#include "esp32_tests.h"      /* numxt_ctx_t */
+#include "numx/numx_types.h"  /* numx_real_t, numx_status_t */
+
+/**
+ * @brief  Absolute value of a numx_real_t — no <math.h> required.
+ * @param[in] x  Input value.
+ * @return |x|
+ */
+static inline numx_real_t numxt_absf(numx_real_t x)
+{
+    return x < (numx_real_t)0 ? -x : x;
+}
+
+/**
+ * @brief  Print a suite header line.
+ * @param[in] name  Suite name string.
+ */
+void suite(const char *name);
+
+/**
+ * @brief  Assert |got - ref| <= tol and record the result in ctx.
+ * @param[in,out] ctx    Test context.
+ * @param[in]     label  Human-readable assertion label.
+ * @param[in]     got    Computed value.
+ * @param[in]     ref    Expected value.
+ * @param[in]     tol    Absolute tolerance.
+ */
+void chk_f(numxt_ctx_t *ctx, const char *label,
+           numx_real_t got, numx_real_t ref, numx_real_t tol);
+
+/**
+ * @brief  Assert got == exp (status codes) and record the result in ctx.
+ * @param[in,out] ctx    Test context.
+ * @param[in]     label  Human-readable assertion label.
+ * @param[in]     got    Returned status code.
+ * @param[in]     exp    Expected status code.
+ */
+void chk_rc(numxt_ctx_t *ctx, const char *label,
+            numx_status_t got, numx_status_t exp);
+
+/**
+ * @brief  Assert cond != 0 and record the result in ctx.
+ * @param[in,out] ctx    Test context.
+ * @param[in]     label  Human-readable assertion label.
+ * @param[in]     cond   Boolean condition.
+ */
+void chk_true(numxt_ctx_t *ctx, const char *label, int cond);
+
+#endif /* NUMX_TEST_HELPERS_H */

--- a/tests/esp32_tests/test_integrate.c
+++ b/tests/esp32_tests/test_integrate.c
@@ -1,0 +1,78 @@
+#include "test_helpers.h"
+#include "math_helpers.h"
+#include "numx/integrate.h"
+
+void test_integrate(numxt_ctx_t *ctx)
+{
+    numx_real_t r;
+
+    suite("integrate / trap");
+    {
+        chk_rc(ctx, "trap const rc", numx_integrate_trap(f_one,0,1,100,&r), NUMX_OK);
+        chk_f (ctx,"trap const=1",   r, 1.0f, 1e-3f);
+
+        numx_integrate_trap(f_xlin,0,1,100,&r);
+        chk_f (ctx,"trap linear=0.5",r, 0.5f, 1e-3f);
+
+        numx_integrate_trap(f_xsq,0,1,1000,&r);
+        chk_f (ctx,"trap x^2=1/3",   r, 1.0f/3.0f, 1e-3f);
+
+        numx_real_t r1,r2;
+        numx_integrate_trap(f_xlin,0,2,100,&r1);
+        numx_integrate_trap(f_neg_x,0,2,100,&r2);
+        chk_f (ctx,"trap linearity", r1+r2, 0.0f, 1e-3f);
+
+        numx_integrate_trap(f_one,0,1,1,&r);
+        chk_f (ctx,"trap n=1",       r, 1.0f, 1e-3f);
+
+        chk_rc(ctx, "trap null-f",   numx_integrate_trap(NULL,0,1,10,&r),    NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "trap null-out", numx_integrate_trap(f_one,0,1,10,NULL), NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "trap a>b",      numx_integrate_trap(f_one,1,0,10,&r),   NUMX_ERR_INVALID_ARG);
+        chk_rc(ctx, "trap a=b",      numx_integrate_trap(f_one,1,1,10,&r),   NUMX_ERR_INVALID_ARG);
+        chk_rc(ctx, "trap n=0",      numx_integrate_trap(f_one,0,1,0,&r),    NUMX_ERR_INVALID_ARG);
+    }
+
+    suite("integrate / simpson");
+    {
+        chk_rc(ctx, "simp const rc", numx_integrate_simpson(f_one,0,1,2,&r), NUMX_OK);
+        chk_f (ctx,"simp const=1",      r, 1.0f,       1e-5f);
+
+        numx_integrate_simpson(f_xlin,0,1,2,&r);
+        chk_f (ctx,"simp linear=0.5",   r, 0.5f,       1e-5f);
+
+        numx_integrate_simpson(f_xsq,0,1,4,&r);
+        chk_f (ctx,"simp x^2=1/3",      r, 1.0f/3.0f, 1e-5f);
+
+        numx_integrate_simpson(f_xcb,0,1,4,&r);
+        chk_f (ctx,"simp x^3=0.25",     r, 0.25f,      1e-5f);
+
+        numx_integrate_simpson(f_xsq,0,3,6,&r);
+        chk_f (ctx,"simp x^2 [0,3]=9",  r, 9.0f,       1e-4f);
+
+        chk_rc(ctx, "simp odd-n rejected",  numx_integrate_simpson(f_one,0,1,3,&r),  NUMX_ERR_INVALID_ARG);
+        chk_rc(ctx, "simp n<2 rejected",    numx_integrate_simpson(f_one,0,1,0,&r),  NUMX_ERR_INVALID_ARG);
+        chk_rc(ctx, "simp null-f",          numx_integrate_simpson(NULL,0,1,4,&r),   NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "simp null-out",        numx_integrate_simpson(f_one,0,1,4,NULL),NUMX_ERR_NULL_PTR);
+    }
+
+    suite("integrate / gauss");
+    {
+        chk_rc(ctx, "gauss2 linear rc", numx_integrate_gauss(f_xlin,0,1,2,&r), NUMX_OK);
+        chk_f (ctx,"gauss2 linear=0.5",r, 0.5f,       1e-5f);
+
+        numx_integrate_gauss(f_xsq,0,1,4,&r);
+        chk_f (ctx,"gauss4 x^2=1/3",   r, 1.0f/3.0f, 1e-5f);
+
+        numx_integrate_gauss(f_xcb,0,1,8,&r);
+        chk_f (ctx,"gauss8 x^3=0.25",  r, 0.25f,      1e-5f);
+
+        numx_integrate_gauss(f_one,-3,3,8,&r);
+        chk_f (ctx,"gauss8 const [-3,3]=6", r, 6.0f,  1e-5f);
+
+        chk_rc(ctx, "gauss null-f",       numx_integrate_gauss(NULL,0,1,4,&r),    NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "gauss null-out",     numx_integrate_gauss(f_one,0,1,4,NULL), NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "gauss bad-npts=3",   numx_integrate_gauss(f_one,0,1,3,&r),   NUMX_ERR_INVALID_ARG);
+        chk_rc(ctx, "gauss bad-npts=16",  numx_integrate_gauss(f_one,0,1,16,&r),  NUMX_ERR_INVALID_ARG);
+        chk_rc(ctx, "gauss a>b",          numx_integrate_gauss(f_one,1,0,4,&r),   NUMX_ERR_INVALID_ARG);
+    }
+}

--- a/tests/esp32_tests/test_interpolate.c
+++ b/tests/esp32_tests/test_interpolate.c
@@ -1,0 +1,109 @@
+#include "test_helpers.h"
+#include "math_helpers.h"
+#include "numx/interpolate.h"
+
+void test_interpolate(numxt_ctx_t *ctx)
+{
+    numx_real_t r;
+
+    suite("interp / linear");
+    {
+        numx_real_t xs[3]={0,1,2}, ys[3]={0,1,4};
+        chk_rc(ctx, "linear rc", numx_interp_linear(xs,ys,3,0.5f,&r), NUMX_OK);
+        chk_f (ctx,"linear x=0.5 → 0.5",  r, 0.5f, 1e-5f);
+
+        numx_interp_linear(xs,ys,3,1.5f,&r);
+        chk_f (ctx,"linear x=1.5 → 2.5",  r, 2.5f, 1e-5f);
+
+        numx_real_t xs4[4]={0,1,3,6}, ys4[4]={1,3,2,5};
+        int ok=1;
+        for(int i=0;i<4;i++){
+            numx_interp_linear(xs4,ys4,4,xs4[i],&r);
+            if(numxt_absf(r-ys4[i])>1e-4f){ok=0;break;}
+        }
+        chk_true(ctx, "linear at knots", ok);
+
+        numx_real_t xsc[3]={1,2,3}, ysc[3]={10,20,30};
+        numx_interp_linear(xsc,ysc,3,0.0f,&r);
+        chk_f (ctx,"linear clamp-below", r, 10.0f, 1e-5f);
+        numx_interp_linear(xsc,ysc,3,5.0f,&r);
+        chk_f (ctx,"linear clamp-above", r, 30.0f, 1e-5f);
+
+        numx_real_t x2[2]={0,4}, y2[2]={0,8};
+        numx_interp_linear(x2,y2,2,2.0f,&r);
+        chk_f (ctx,"linear n=2 midpoint=4", r, 4.0f, 1e-5f);
+
+        chk_rc(ctx, "linear null-xs",  numx_interp_linear(NULL,ys,3,0.5f,&r),  NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "linear null-ys",  numx_interp_linear(xs,NULL,3,0.5f,&r),  NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "linear null-out", numx_interp_linear(xs,ys,3,0.5f,NULL),  NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "linear n<2",      numx_interp_linear(xs,ys,1,0.5f,&r),    NUMX_ERR_INVALID_ARG);
+        chk_rc(ctx, "linear n=0",      numx_interp_linear(xs,ys,0,0.5f,&r),    NUMX_ERR_INVALID_ARG);
+    }
+
+    suite("interp / spline_cubic");
+    {
+        numx_real_t xsl[4]={0,1,2,3}, ysl[4]={0,1,2,3}, m[4];
+        chk_rc(ctx, "spline precompute rc", numx_interp_spline_precompute(xsl,ysl,4,m), NUMX_OK);
+        numx_interp_spline_eval(xsl,ysl,m,4,0.5f,&r);
+        chk_f (ctx,"spline linear data x=0.5", r, 0.5f, 1e-4f);
+        numx_interp_spline_eval(xsl,ysl,m,4,1.7f,&r);
+        chk_f (ctx,"spline linear data x=1.7", r, 1.7f, 1e-4f);
+
+        numx_real_t xsc[4]={0,1,2,3}, ysc[4]={0,1,4,9};
+        chk_rc(ctx, "spline cubic oneshot rc", numx_interp_spline_cubic(xsc,ysc,4,0.5f,&r), NUMX_OK);
+        chk_f (ctx,"spline cubic at 0.5",     r, 0.35f, 5e-3f);
+
+        numx_real_t xsb[5]={0,1,2,3,4}, ysb[5]={1,3,2,5,4}, mb[5];
+        numx_interp_spline_precompute(xsb,ysb,5,mb);
+        int ok=1;
+        for(int i=0;i<5;i++){
+            numx_interp_spline_eval(xsb,ysb,mb,5,xsb[i],&r);
+            if(numxt_absf(r-ysb[i])>1e-3f){ok=0;break;}
+        }
+        chk_true(ctx, "spline at knots", ok);
+
+        numx_real_t xscl[3]={1,2,3}, yscl[3]={1,4,9};
+        numx_interp_spline_cubic(xscl,yscl,3,0.0f,&r);
+        chk_f (ctx,"spline clamp-below", r, 1.0f, 1e-3f);
+        numx_interp_spline_cubic(xscl,yscl,3,5.0f,&r);
+        chk_f (ctx,"spline clamp-above", r, 9.0f, 1e-3f);
+
+        numx_real_t xs2[2]={0,2}, ys2[2]={0,4};
+        numx_interp_spline_cubic(xs2,ys2,2,1.0f,&r);
+        chk_f (ctx,"spline n=2 linear midpoint=2", r, 2.0f, 1e-4f);
+
+        chk_rc(ctx, "spline precompute null-xs",
+               numx_interp_spline_precompute(NULL,ysl,4,m), NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "spline precompute null-ys",
+               numx_interp_spline_precompute(xsl,NULL,4,m), NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "spline precompute null-m",
+               numx_interp_spline_precompute(xsl,ysl,4,NULL),NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "spline precompute n<2",
+               numx_interp_spline_precompute(xsl,ysl,1,m),   NUMX_ERR_INVALID_ARG);
+    }
+
+    suite("interp / chebyshev");
+    {
+        chk_rc(ctx, "cheb const rc", numx_interp_chebyshev(f_c3,4,0,1,0.5f,&r), NUMX_OK);
+        chk_f (ctx,"cheb constant=3",  r, 3.0f, 1e-4f);
+
+        numx_interp_chebyshev(f_xlin,4,0,2,1.0f,&r);
+        chk_f (ctx,"cheb linear=1.0",  r, 1.0f, 1e-4f);
+
+        numx_interp_chebyshev(f_sq,4,-1,1,0.5f,&r);
+        chk_f (ctx,"cheb x^2 at 0.5",  r, 0.25f,1e-4f);
+
+        numx_interp_chebyshev(f_sq,4,-1,1,0.0f,&r);
+        chk_f (ctx,"cheb x^2 at 0",    r, 0.0f, 1e-4f);
+
+        numx_interp_chebyshev(f_sq,2,-1,1,0.0f,&r);
+        chk_f (ctx,"cheb n=2 x^2 at 0 ~ 0.5", r, 0.5f, 1e-4f);
+
+        chk_rc(ctx, "cheb null-f",   numx_interp_chebyshev(NULL,4,0,1,0.5f,&r),    NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "cheb null-out", numx_interp_chebyshev(f_sq,4,0,1,0.5f,NULL),  NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "cheb b<=a",     numx_interp_chebyshev(f_sq,4,1,0,0.5f,&r),    NUMX_ERR_INVALID_ARG);
+        chk_rc(ctx, "cheb a=b",      numx_interp_chebyshev(f_sq,4,1,1,0.5f,&r),    NUMX_ERR_INVALID_ARG);
+        chk_rc(ctx, "cheb n<2",      numx_interp_chebyshev(f_sq,1,0,1,0.5f,&r),    NUMX_ERR_INVALID_ARG);
+        chk_rc(ctx, "cheb n=0",      numx_interp_chebyshev(f_sq,0,0,1,0.5f,&r),    NUMX_ERR_INVALID_ARG);
+    }
+}

--- a/tests/esp32_tests/test_linalg.c
+++ b/tests/esp32_tests/test_linalg.c
@@ -1,0 +1,233 @@
+#include <string.h>
+#include "test_helpers.h"
+#include "numx/linalg.h"
+
+void test_linalg(numxt_ctx_t *ctx)
+{
+    numx_real_t r;
+
+    /* ── vec_dot ──────────────────────────────────────────────── */
+    suite("linalg / vec_dot");
+    {
+        numx_real_t a3[3]={1,2,3}, b3[3]={4,5,6};
+        chk_rc (ctx,"vec_dot known-answer rc",
+                numx_vec_dot(a3,b3,3,&r), NUMX_OK);
+        chk_f  (ctx,"vec_dot [1,2,3]·[4,5,6]=32", r, 32.0f, 1e-5f);
+
+        numx_real_t ax[3]={1,0,0}, bx[3]={0,1,0};
+        numx_vec_dot(ax,bx,3,&r);
+        chk_f  (ctx,"vec_dot orthogonal = 0",  r, 0.0f, 1e-6f);
+
+        numx_real_t r2;
+        numx_vec_dot(a3,b3,3,&r);
+        numx_vec_dot(b3,a3,3,&r2);
+        chk_true(ctx,"vec_dot commutative", numxt_absf(r-r2)<1e-6f);
+
+        numx_real_t v[2]={3,4};
+        numx_vec_dot(v,v,2,&r);
+        chk_f  (ctx,"vec_dot self=[3,4] = 25", r, 25.0f, 1e-5f);
+
+        numx_real_t a1[1]={7}, b1[1]={3};
+        numx_vec_dot(a1,b1,1,&r);
+        chk_f  (ctx,"vec_dot n=1: 7*3=21", r, 21.0f, 1e-5f);
+
+        numx_real_t z3[3]={0,0,0};
+        numx_vec_dot(z3,b3,3,&r);
+        chk_f  (ctx,"vec_dot zero vec = 0", r, 0.0f, 1e-6f);
+
+        chk_rc (ctx,"vec_dot null-a",  numx_vec_dot(NULL,b3,3,&r), NUMX_ERR_NULL_PTR);
+        chk_rc (ctx,"vec_dot null-b",  numx_vec_dot(a3,NULL,3,&r), NUMX_ERR_NULL_PTR);
+        chk_rc (ctx,"vec_dot null-out",numx_vec_dot(a3,b3,3,NULL), NUMX_ERR_NULL_PTR);
+        chk_rc (ctx,"vec_dot n=0",     numx_vec_dot(a3,b3,0,&r),   NUMX_ERR_INVALID_ARG);
+    }
+
+    /* ── vec_norm ─────────────────────────────────────────────── */
+    suite("linalg / vec_norm");
+    {
+        numx_real_t v[2]={3,4};
+        chk_rc(ctx, "vec_norm L2 rc", numx_vec_norm(v,2,NUMX_NORM_L2,&r), NUMX_OK);
+        chk_f (ctx,"vec_norm L2 [3,4]=5",   r, 5.0f, 1e-5f);
+
+        numx_real_t v3[3]={3,-4,0};
+        numx_vec_norm(v3,3,NUMX_NORM_L1,&r);
+        chk_f (ctx,"vec_norm L1 [3,-4,0]=7", r, 7.0f, 1e-5f);
+
+        numx_real_t v3b[3]={3,-5,4};
+        numx_vec_norm(v3b,3,NUMX_NORM_INF,&r);
+        chk_f (ctx,"vec_norm Linf [3,-5,4]=5", r, 5.0f, 1e-5f);
+
+        numx_real_t unit[3]={1,0,0};
+        numx_vec_norm(unit,3,NUMX_NORM_L2,&r);
+        chk_f (ctx,"vec_norm unit = 1", r, 1.0f, 1e-6f);
+
+        numx_real_t zero[3]={0,0,0};
+        numx_vec_norm(zero,3,NUMX_NORM_L2,&r);
+        chk_f (ctx,"vec_norm zero = 0", r, 0.0f, 1e-6f);
+
+        chk_rc(ctx, "vec_norm null-a",   numx_vec_norm(NULL,3,NUMX_NORM_L2,&r), NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "vec_norm null-out", numx_vec_norm(v,2,NUMX_NORM_L2,NULL),  NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "vec_norm bad-type", numx_vec_norm(v,2,(numx_norm_t)99,&r), NUMX_ERR_INVALID_ARG);
+    }
+
+    /* ── vec_cross3 ───────────────────────────────────────────── */
+    suite("linalg / vec_cross3");
+    {
+        numx_real_t a[3]={1,0,0}, b[3]={0,1,0}, c[3];
+        chk_rc(ctx, "vec_cross3 rc", numx_vec_cross3(a,b,c), NUMX_OK);
+        chk_f (ctx,"vec_cross3 x×y [0]", c[0], 0.0f, 1e-6f);
+        chk_f (ctx,"vec_cross3 x×y [1]", c[1], 0.0f, 1e-6f);
+        chk_f (ctx,"vec_cross3 x×y [2]", c[2], 1.0f, 1e-6f);
+
+        numx_real_t a2[3]={1,2,3}, b2[3]={4,5,6}, axb[3], bxa[3];
+        numx_vec_cross3(a2,b2,axb);
+        numx_vec_cross3(b2,a2,bxa);
+        chk_f (ctx,"vec_cross3 anticomm [0]", axb[0]+bxa[0], 0.0f, 1e-5f);
+        chk_f (ctx,"vec_cross3 anticomm [1]", axb[1]+bxa[1], 0.0f, 1e-5f);
+        chk_f (ctx,"vec_cross3 anticomm [2]", axb[2]+bxa[2], 0.0f, 1e-5f);
+
+        numx_real_t pa[3]={2,0,0}, pb[3]={5,0,0}, pc[3];
+        numx_vec_cross3(pa,pb,pc);
+        chk_f (ctx,"vec_cross3 parallel [0]", pc[0], 0.0f, 1e-6f);
+        chk_f (ctx,"vec_cross3 parallel [2]", pc[2], 0.0f, 1e-6f);
+
+        numx_real_t aa[3]={1,0,0}, ba[3]={0,1,0};
+        numx_vec_cross3(aa,ba,aa);
+        chk_f (ctx,"vec_cross3 alias-safe [0]", aa[0], 0.0f, 1e-6f);
+        chk_f (ctx,"vec_cross3 alias-safe [1]", aa[1], 0.0f, 1e-6f);
+        chk_f (ctx,"vec_cross3 alias-safe [2]", aa[2], 1.0f, 1e-6f);
+
+        chk_rc(ctx, "vec_cross3 null-a", numx_vec_cross3(NULL,b,c), NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "vec_cross3 null-b", numx_vec_cross3(a,NULL,c), NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "vec_cross3 null-c", numx_vec_cross3(a,b,NULL), NUMX_ERR_NULL_PTR);
+    }
+
+    /* ── mat_mul ──────────────────────────────────────────────── */
+    suite("linalg / mat_mul");
+    {
+        numx_real_t A[4]={1,2,3,4}, B[4]={5,6,7,8}, C[4];
+        chk_rc(ctx, "mat_mul 2×2 rc", numx_mat_mul(A,2,2,B,2,2,C), NUMX_OK);
+        chk_f (ctx,"mat_mul 2×2 C[0,0]=19", C[0], 19.0f, 1e-5f);
+        chk_f (ctx,"mat_mul 2×2 C[0,1]=22", C[1], 22.0f, 1e-5f);
+        chk_f (ctx,"mat_mul 2×2 C[1,0]=43", C[2], 43.0f, 1e-5f);
+        chk_f (ctx,"mat_mul 2×2 C[1,1]=50", C[3], 50.0f, 1e-5f);
+
+        numx_real_t A23[6]={1,2,3,4,5,6}, B32[6]={7,8,9,10,11,12}, C22[4];
+        numx_mat_mul(A23,2,3,B32,3,2,C22);
+        chk_f (ctx,"mat_mul 2x3*3x2 C[0,0]=58",  C22[0], 58.0f,  1e-4f);
+        chk_f (ctx,"mat_mul 2x3*3x2 C[0,1]=64",  C22[1], 64.0f,  1e-4f);
+        chk_f (ctx,"mat_mul 2x3*3x2 C[1,0]=139", C22[2], 139.0f, 1e-4f);
+        chk_f (ctx,"mat_mul 2x3*3x2 C[1,1]=154", C22[3], 154.0f, 1e-4f);
+
+        numx_real_t I[4]={1,0,0,1}, AI[4];
+        numx_mat_mul(A,2,2,I,2,2,AI);
+        chk_f (ctx,"mat_mul A*I=A [0]", AI[0], A[0], 1e-6f);
+        chk_f (ctx,"mat_mul A*I=A [1]", AI[1], A[1], 1e-6f);
+        chk_f (ctx,"mat_mul A*I=A [2]", AI[2], A[2], 1e-6f);
+        chk_f (ctx,"mat_mul A*I=A [3]", AI[3], A[3], 1e-6f);
+
+        numx_real_t bad[6]={0};
+        chk_rc(ctx, "mat_mul dim-mismatch", numx_mat_mul(A23,2,3,B,2,2,C), NUMX_ERR_INVALID_ARG);
+        (void)bad;
+        chk_rc(ctx, "mat_mul null-A", numx_mat_mul(NULL,2,2,B,2,2,C), NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "mat_mul null-C", numx_mat_mul(A,2,2,B,2,2,NULL), NUMX_ERR_NULL_PTR);
+    }
+
+    /* ── mat_transpose ────────────────────────────────────────── */
+    suite("linalg / mat_transpose");
+    {
+        numx_real_t A[6]={1,2,3,4,5,6}, AT[6];
+        chk_rc(ctx, "mat_transpose 2x3 rc", numx_mat_transpose(A,2,3,AT), NUMX_OK);
+        chk_f (ctx,"mat_transpose AT[0]=1", AT[0], 1.0f, 1e-6f);
+        chk_f (ctx,"mat_transpose AT[1]=4", AT[1], 4.0f, 1e-6f);
+        chk_f (ctx,"mat_transpose AT[2]=2", AT[2], 2.0f, 1e-6f);
+        chk_f (ctx,"mat_transpose AT[3]=5", AT[3], 5.0f, 1e-6f);
+        chk_f (ctx,"mat_transpose AT[4]=3", AT[4], 3.0f, 1e-6f);
+        chk_f (ctx,"mat_transpose AT[5]=6", AT[5], 6.0f, 1e-6f);
+
+        numx_real_t ATT[6];
+        numx_mat_transpose(AT,3,2,ATT);
+        int ok=1;
+        for(int i=0;i<6;i++) if(numxt_absf(ATT[i]-A[i])>1e-5f){ok=0;break;}
+        chk_true(ctx,"mat_transpose T(T(A))=A", ok);
+
+        numx_real_t S[4]={1,2,3,4};
+        chk_rc(ctx, "mat_transpose_sq 2x2 rc", numx_mat_transpose_sq(S,2), NUMX_OK);
+        chk_f (ctx,"mat_transpose_sq S[0]=1", S[0], 1.0f, 1e-6f);
+        chk_f (ctx,"mat_transpose_sq S[1]=3", S[1], 3.0f, 1e-6f);
+        chk_f (ctx,"mat_transpose_sq S[2]=2", S[2], 2.0f, 1e-6f);
+        chk_f (ctx,"mat_transpose_sq S[3]=4", S[3], 4.0f, 1e-6f);
+
+        numx_real_t S3[9]={1,2,3,4,5,6,7,8,9};
+        numx_real_t orig[9]; memcpy(orig,S3,sizeof(S3));
+        numx_mat_transpose_sq(S3,3);
+        numx_mat_transpose_sq(S3,3);
+        int ok2=1;
+        for(int i=0;i<9;i++) if(numxt_absf(S3[i]-orig[i])>1e-5f){ok2=0;break;}
+        chk_true(ctx,"mat_transpose_sq twice=identity", ok2);
+
+        chk_rc(ctx, "mat_transpose null",    numx_mat_transpose(NULL,2,3,AT),  NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "mat_transpose_sq null", numx_mat_transpose_sq(NULL,2),    NUMX_ERR_NULL_PTR);
+    }
+
+    /* ── mat_det ──────────────────────────────────────────────── */
+    suite("linalg / mat_det");
+    {
+        numx_real_t A1[1]={7};
+        chk_rc(ctx, "mat_det 1×1 rc", numx_mat_det(A1,1,&r), NUMX_OK);
+        chk_f (ctx,"mat_det 1×1 = 7",   r, 7.0f, 1e-5f);
+
+        numx_real_t A2[4]={1,2,3,4};
+        numx_mat_det(A2,2,&r);
+        chk_f (ctx,"mat_det 2×2 = -2",   r, -2.0f, 1e-5f);
+
+        numx_real_t A3[9]={1,2,3,4,5,6,7,8,10};
+        numx_mat_det(A3,3,&r);
+        chk_f (ctx,"mat_det 3×3 = -3",   r, -3.0f, 1e-4f);
+
+        numx_real_t I3[9]={1,0,0,0,1,0,0,0,1};
+        numx_mat_det(I3,3,&r);
+        chk_f (ctx,"mat_det I = 1",      r, 1.0f,  1e-5f);
+
+        numx_real_t Sg[4]={1,2,2,4};
+        numx_mat_det(Sg,2,&r);
+        chk_f (ctx,"mat_det singular = 0", r, 0.0f, 1e-4f);
+
+        chk_rc(ctx, "mat_det null-A",   numx_mat_det(NULL,2,&r), NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "mat_det null-out", numx_mat_det(A2,2,NULL), NUMX_ERR_NULL_PTR);
+    }
+
+    /* ── lu_decompose / lu_solve ──────────────────────────────── */
+    suite("linalg / lu_solve");
+    {
+        numx_real_t A[9]={2,1,-1,-3,-1,2,-2,1,2};
+        numx_real_t b[3]={8,-11,-3}, LU[9], x[3];
+        numx_idx_t piv[3];
+        chk_rc(ctx, "lu_decompose 3×3 rc", numx_lu_decompose(A,3,LU,piv), NUMX_OK);
+        chk_rc(ctx, "lu_solve 3×3 rc",     numx_lu_solve(LU,piv,3,b,x),  NUMX_OK);
+        chk_f (ctx,"lu_solve x[0]=2",  x[0],  2.0f, 1e-4f);
+        chk_f (ctx,"lu_solve x[1]=3",  x[1],  3.0f, 1e-4f);
+        chk_f (ctx,"lu_solve x[2]=-1", x[2], -1.0f, 1e-4f);
+
+        numx_real_t AI[4]={1,0,0,1}, bI[2]={5,7}, LUI[4], xI[2];
+        numx_idx_t pivI[2];
+        numx_lu_decompose(AI,2,LUI,pivI);
+        numx_lu_solve(LUI,pivI,2,bI,xI);
+        chk_f (ctx,"lu_solve I*x x[0]=5", xI[0], 5.0f, 1e-5f);
+        chk_f (ctx,"lu_solve I*x x[1]=7", xI[1], 7.0f, 1e-5f);
+
+        numx_real_t Ax[3];
+        numx_mat_mul(A,3,3,x,3,1,Ax);
+        chk_f (ctx,"lu_solve residual[0]", Ax[0], b[0], 1e-3f);
+        chk_f (ctx,"lu_solve residual[1]", Ax[1], b[1], 1e-3f);
+        chk_f (ctx,"lu_solve residual[2]", Ax[2], b[2], 1e-3f);
+
+        numx_real_t Asg[4]={1,2,2,4}, LUsg[4];
+        numx_idx_t pivsg[2];
+        chk_rc(ctx, "lu_decompose singular", numx_lu_decompose(Asg,2,LUsg,pivsg), NUMX_ERR_SINGULAR);
+
+        chk_rc(ctx, "lu_decompose null-A",  numx_lu_decompose(NULL,2,LUI,pivI),  NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "lu_decompose null-LU", numx_lu_decompose(AI,2,NULL,pivI),   NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "lu_solve null-LU",     numx_lu_solve(NULL,pivI,2,bI,xI),   NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "lu_solve null-x",      numx_lu_solve(LUI,pivI,2,bI,NULL),  NUMX_ERR_NULL_PTR);
+    }
+}

--- a/tests/esp32_tests/test_ode.c
+++ b/tests/esp32_tests/test_ode.c
@@ -1,0 +1,75 @@
+#include "test_helpers.h"
+#include "math_helpers.h"
+#include "numx/ode.h"
+
+void test_ode(numxt_ctx_t *ctx)
+{
+    suite("ode / rk4");
+    {
+        numx_real_t y[1]={1.0f};
+        chk_rc(ctx, "rk4 growth rc", numx_ode_rk4(ode_growth,0,y,1,1e-3f,1000,y), NUMX_OK);
+        chk_f (ctx,"rk4 growth y(1)=e", y[0], 2.71828f, 1e-3f);
+
+        numx_real_t yd[1]={1.0f};
+        numx_ode_rk4(ode_decay,0,yd,1,1e-3f,1000,yd);
+        chk_f (ctx,"rk4 decay y(1)=1/e", yd[0], 0.36788f, 1e-3f);
+
+        numx_real_t yg2[1]={1.0f};
+        numx_ode_rk4(ode_growth,0,yg2,1,1e-3f,2000,yg2);
+        chk_f (ctx,"rk4 growth y(2)=e^2", yg2[0], 7.38906f, 1e-2f);
+
+        numx_real_t yh[2]={1.0f,0.0f};
+        numx_real_t E0 = 0.5f*(yh[0]*yh[0]+yh[1]*yh[1]);
+        numx_ode_rk4(ode_harm,0,yh,2,1e-3f,1000,yh);
+        numx_real_t E1 = 0.5f*(yh[0]*yh[0]+yh[1]*yh[1]);
+        chk_true(ctx, "rk4 harmonic energy conserved", numxt_absf(E1-E0)<1e-2f);
+
+        numx_real_t ys[1]={1.0f};
+        numx_ode_rk4(ode_growth,0,ys,1,0.01f,1,ys);
+        chk_f (ctx,"rk4 single step", ys[0], 1.01005f, 1e-4f);
+
+        numx_real_t ye[1]={1.0f};
+        chk_rc(ctx, "rk4 rhs-error propagated",
+               numx_ode_rk4(ode_err,0,ye,1,0.1f,10,ye), NUMX_ERR_SINGULAR);
+
+        numx_real_t y0[1]={1.0f}, yout[1];
+        chk_rc(ctx, "rk4 null-f",    numx_ode_rk4(NULL,0,y0,1,0.1f,10,yout), NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "rk4 null-y0",   numx_ode_rk4(ode_growth,0,NULL,1,0.1f,10,yout),NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "rk4 null-yout", numx_ode_rk4(ode_growth,0,y0,1,0.1f,10,NULL),  NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "rk4 h=0",       numx_ode_rk4(ode_growth,0,y0,1,0.0f,10,yout),  NUMX_ERR_INVALID_ARG);
+        chk_rc(ctx, "rk4 h<0",       numx_ode_rk4(ode_growth,0,y0,1,-0.1f,10,yout), NUMX_ERR_INVALID_ARG);
+        chk_rc(ctx, "rk4 steps=0",   numx_ode_rk4(ode_growth,0,y0,1,0.1f,0,yout),   NUMX_ERR_INVALID_ARG);
+        chk_rc(ctx, "rk4 n=0",       numx_ode_rk4(ode_growth,0,y0,0,0.1f,10,yout),  NUMX_ERR_INVALID_ARG);
+    }
+
+    suite("ode / rk45");
+    {
+        numx_real_t yg[1]={1.0f};
+        chk_rc(ctx, "rk45 growth rc", numx_ode_rk45(ode_growth,0,1.0f,yg,1,1e-4f,yg), NUMX_OK);
+        chk_f (ctx,"rk45 growth y(1)=e", yg[0], 2.71828f, 1e-3f);
+
+        numx_real_t yd[1]={1.0f};
+        numx_ode_rk45(ode_decay,0,1.0f,yd,1,1e-4f,yd);
+        chk_f (ctx,"rk45 decay y(1)=1/e", yd[0], 0.36788f, 1e-3f);
+
+        numx_real_t yh[2]={1.0f,0.0f};
+        numx_real_t E0 = 0.5f*(yh[0]*yh[0]+yh[1]*yh[1]);
+        numx_ode_rk45(ode_harm,0,10.0f,yh,2,1e-4f,yh);
+        numx_real_t E1 = 0.5f*(yh[0]*yh[0]+yh[1]*yh[1]);
+        chk_true(ctx, "rk45 harmonic energy conserved", numxt_absf(E1-E0)<1e-2f);
+
+        numx_real_t ye[1]={1.0f};
+        chk_rc(ctx, "rk45 rhs-error propagated",
+               numx_ode_rk45(ode_err,0,1.0f,ye,1,1e-4f,ye), NUMX_ERR_SINGULAR);
+
+        numx_real_t y0[1]={1.0f}, yout[1];
+        chk_rc(ctx, "rk45 null-f",    numx_ode_rk45(NULL,0,1,y0,1,1e-4f,yout),          NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "rk45 null-y0",   numx_ode_rk45(ode_growth,0,1,NULL,1,1e-4f,yout),  NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "rk45 null-yout", numx_ode_rk45(ode_growth,0,1,y0,1,1e-4f,NULL),    NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "rk45 t1<=t0",    numx_ode_rk45(ode_growth,1,0,y0,1,1e-4f,yout),    NUMX_ERR_INVALID_ARG);
+        chk_rc(ctx, "rk45 t1=t0",     numx_ode_rk45(ode_growth,1,1,y0,1,1e-4f,yout),    NUMX_ERR_INVALID_ARG);
+        chk_rc(ctx, "rk45 tol=0",     numx_ode_rk45(ode_growth,0,1,y0,1,0.0f,yout),     NUMX_ERR_INVALID_ARG);
+        chk_rc(ctx, "rk45 tol<0",     numx_ode_rk45(ode_growth,0,1,y0,1,-1e-4f,yout),   NUMX_ERR_INVALID_ARG);
+        chk_rc(ctx, "rk45 n=0",       numx_ode_rk45(ode_growth,0,1,y0,0,1e-4f,yout),    NUMX_ERR_INVALID_ARG);
+    }
+}

--- a/tests/esp32_tests/test_poly.c
+++ b/tests/esp32_tests/test_poly.c
@@ -1,0 +1,91 @@
+#include "test_helpers.h"
+#include "numx/poly.h"
+
+void test_poly(numxt_ctx_t *ctx)
+{
+    numx_real_t r;
+
+    suite("poly / eval");
+    {
+        numx_real_t c1[3]={1,0,1};
+        chk_rc(ctx, "poly_eval rc", numx_poly_eval(c1,2,3.0f,&r), NUMX_OK);
+        chk_f (ctx,"poly x^2+1 at 3=10",   r, 10.0f, 1e-4f);
+
+        numx_real_t c2[4]={1,0,-2,1};
+        numx_poly_eval(c2,3,2.0f,&r);
+        chk_f (ctx,"poly x^3-2x+1 at 2=5", r, 5.0f,  1e-4f);
+
+        numx_real_t c3[3]={3,7,-2};
+        numx_poly_eval(c3,2,0.0f,&r);
+        chk_f (ctx,"poly at 0 = const=-2",  r,-2.0f,  1e-5f);
+
+        numx_real_t c4[1]={5};
+        numx_poly_eval(c4,0,99.0f,&r);
+        chk_f (ctx,"poly degree-0 = 5",      r, 5.0f,  1e-5f);
+
+        numx_real_t c5[3]={2,3,4};
+        numx_poly_eval(c5,2,5.0f,&r);
+        chk_f (ctx,"poly Horner 2x^2+3x+4 at 5=69", r, 69.0f, 1e-3f);
+
+        numx_real_t c6[4]={1,-6,11,-6};
+        numx_poly_eval(c6,3,1.0f,&r); chk_f(ctx,"poly (x-1)(x-2)(x-3) at 1=0", r, 0.0f, 1e-4f);
+        numx_poly_eval(c6,3,2.0f,&r); chk_f(ctx,"poly (x-1)(x-2)(x-3) at 2=0", r, 0.0f, 1e-4f);
+        numx_poly_eval(c6,3,3.0f,&r); chk_f(ctx,"poly (x-1)(x-2)(x-3) at 3=0", r, 0.0f, 1e-4f);
+
+        numx_real_t c7[3]={1,-3,2};
+        numx_poly_eval(c7,2,1.0f,&r);
+        chk_f (ctx,"poly x^2-3x+2 at 1=0",  r, 0.0f, 1e-4f);
+
+        chk_rc(ctx, "poly_eval null-c",   numx_poly_eval(NULL,2,1.0f,&r),   NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "poly_eval null-out", numx_poly_eval(c1,2,1.0f,NULL),   NUMX_ERR_NULL_PTR);
+    }
+
+    suite("poly / roots");
+    {
+        numx_real_t c1[2]={1,1}, ro[3];
+        numx_size_t nr;
+        chk_rc(ctx, "poly_roots linear rc", numx_poly_roots(c1,1,ro,&nr,1e-4f), NUMX_OK);
+        chk_true(ctx, "poly_roots linear nroots=1", nr==1);
+        chk_f(ctx, "poly_roots linear root=-1", ro[0], -1.0f, 1e-3f);
+
+        numx_real_t c2[3]={1,-5,6}, ro2[2];
+        numx_poly_roots(c2,2,ro2,&nr,1e-4f);
+        chk_true(ctx, "poly_roots quad nroots=2", nr==2);
+        numx_real_t r0,r1;
+        numx_poly_eval(c2,2,ro2[0],&r0);
+        numx_poly_eval(c2,2,ro2[1],&r1);
+        chk_f(ctx, "poly_roots quad f(r0)≈0", r0, 0.0f, 1e-3f);
+        chk_f(ctx, "poly_roots quad f(r1)≈0", r1, 0.0f, 1e-3f);
+        {
+            int found2 = (numxt_absf(ro2[0]-2.0f)<1e-3f || numxt_absf(ro2[1]-2.0f)<1e-3f);
+            int found3 = (numxt_absf(ro2[0]-3.0f)<1e-3f || numxt_absf(ro2[1]-3.0f)<1e-3f);
+            chk_true(ctx, "poly_roots quad root=2 found", found2);
+            chk_true(ctx, "poly_roots quad root=3 found", found3);
+        }
+
+        numx_real_t c3[4]={1,-6,11,-6}, ro3[3];
+        numx_poly_roots(c3,3,ro3,&nr,1e-4f);
+        int ok=1;
+        for(numx_size_t i=0;i<nr;i++){
+            numx_real_t fv; numx_poly_eval(c3,3,ro3[i],&fv);
+            if(numxt_absf(fv)>1e-2f){ok=0;break;}
+        }
+        chk_true(ctx, "poly_roots cubic residuals all ≈ 0", ok);
+
+        numx_real_t c4[4]={1,0,0,-8}, ro4[3];
+        numx_poly_roots(c4,3,ro4,&nr,1e-4f);
+        chk_true(ctx, "poly_roots x^3-8 has root", nr>=1);
+        {
+            int root2_found = 0;
+            for(numx_size_t i=0;i<nr;i++)
+                if(numxt_absf(ro4[i]-2.0f)<1e-2f){root2_found=1;break;}
+            chk_true(ctx, "poly_roots x^3-8 real root≈2", root2_found);
+        }
+
+        chk_rc(ctx, "poly_roots null-c",   numx_poly_roots(NULL,2,ro2,&nr,1e-4f), NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "poly_roots null-out", numx_poly_roots(c2,2,NULL,&nr,1e-4f),  NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "poly_roots null-nr",  numx_poly_roots(c2,2,ro2,NULL,1e-4f),  NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "poly_roots degree=0", numx_poly_roots(c2,0,ro2,&nr,1e-4f),   NUMX_ERR_INVALID_ARG);
+        chk_rc(ctx, "poly_roots tol=0",    numx_poly_roots(c2,2,ro2,&nr,0.0f),    NUMX_ERR_INVALID_ARG);
+    }
+}

--- a/tests/esp32_tests/test_roots.c
+++ b/tests/esp32_tests/test_roots.c
@@ -1,0 +1,76 @@
+#include "test_helpers.h"
+#include "math_helpers.h"
+#include "numx/roots.h"
+
+void test_roots(numxt_ctx_t *ctx)
+{
+    numx_real_t r;
+
+    suite("roots / bisect");
+    {
+        chk_rc(ctx, "bisect linear rc", numx_root_bisect(f_lin,0,5,1e-5f,&r), NUMX_OK);
+        chk_f (ctx,"bisect linear root=2",     r, 2.0f, 1e-5f);
+
+        numx_root_bisect(f_quad,0,5,1e-5f,&r);
+        chk_f (ctx,"bisect quad+ root=2",      r, 2.0f, 1e-5f);
+
+        numx_root_bisect(f_quad,-5,0,1e-5f,&r);
+        chk_f (ctx,"bisect quad- root=-2",     r,-2.0f, 1e-5f);
+
+        numx_root_bisect(f_cubic,0.5f,2.0f,1e-5f,&r);
+        chk_true(ctx, "bisect cubic residual",  numxt_absf(f_cubic(r)) < 1e-3f);
+
+        numx_root_bisect(f_lin,2,5,1e-5f,&r);
+        chk_f (ctx,"bisect root@left=2",       r, 2.0f, 1e-5f);
+
+        numx_root_bisect(f_lin,0,2,1e-5f,&r);
+        chk_f (ctx,"bisect root@right=2",      r, 2.0f, 1e-5f);
+
+        chk_rc(ctx, "bisect null-f",    numx_root_bisect(NULL,0,5,1e-5f,&r),   NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "bisect null-out",  numx_root_bisect(f_lin,0,5,1e-5f,NULL),NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "bisect no-bracket",numx_root_bisect(f_quad,3,5,1e-5f,&r), NUMX_ERR_INVALID_ARG);
+        chk_rc(ctx, "bisect tol=0",     numx_root_bisect(f_lin,0,5,0.0f,&r),   NUMX_ERR_INVALID_ARG);
+    }
+
+    suite("roots / newton");
+    {
+        chk_rc(ctx, "newton linear rc", numx_root_newton(f_lin,df_lin,0,1e-5f,&r), NUMX_OK);
+        chk_f (ctx,"newton linear=2",   r, 2.0f, 1e-5f);
+
+        numx_root_newton(f_quad,df_quad,3,1e-5f,&r);
+        chk_f (ctx,"newton quad+=2",    r, 2.0f, 1e-5f);
+
+        numx_root_newton(f_lin,df_lin,2.0f,1e-5f,&r);
+        chk_f (ctx,"newton at-root=2",  r, 2.0f, 1e-5f);
+
+        numx_root_newton(f_cubic,df_cubic,2,1e-5f,&r);
+        chk_true(ctx, "newton cubic residual", numxt_absf(f_cubic(r)) < 1e-3f);
+
+        numx_status_t st = numx_root_newton(f_dbl,df_dbl,1.0f,1e-5f,&r);
+        chk_true(ctx, "newton double-root ok/sing", st==NUMX_OK || st==NUMX_ERR_SINGULAR);
+
+        chk_rc(ctx, "newton null-f",  numx_root_newton(NULL,df_lin,0,1e-5f,&r),    NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "newton null-df", numx_root_newton(f_lin,NULL,0,1e-5f,&r),     NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "newton tol<0",   numx_root_newton(f_lin,df_lin,0,-1.0f,&r),   NUMX_ERR_INVALID_ARG);
+    }
+
+    suite("roots / brent");
+    {
+        chk_rc(ctx, "brent linear rc", numx_root_brent(f_lin,0,5,1e-5f,&r), NUMX_OK);
+        chk_f (ctx,"brent linear=2",       r, 2.0f, 1e-5f);
+
+        numx_root_brent(f_quad,0,5,1e-5f,&r);
+        chk_f (ctx,"brent quad+=2",        r, 2.0f, 1e-5f);
+
+        numx_root_brent(f_cubic,0.5f,1.5f,1e-5f,&r);
+        chk_f (ctx,"brent cubic root=1",   r, 1.0f, 1e-5f);
+
+        numx_root_brent(f_cubic,-1.5f,-0.5f,1e-5f,&r);
+        chk_true(ctx, "brent cubic- residual", numxt_absf(f_cubic(r)) < 1e-3f);
+
+        chk_rc(ctx, "brent null-f",    numx_root_brent(NULL,0,5,1e-5f,&r),    NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "brent null-out",  numx_root_brent(f_lin,0,5,1e-5f,NULL), NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "brent no-bracket",numx_root_brent(f_quad,3,5,1e-5f,&r),  NUMX_ERR_INVALID_ARG);
+        chk_rc(ctx, "brent tol=0",     numx_root_brent(f_lin,0,5,0.0f,&r),    NUMX_ERR_INVALID_ARG);
+    }
+}

--- a/tests/esp32_tests/test_signal.c
+++ b/tests/esp32_tests/test_signal.c
@@ -1,0 +1,201 @@
+#include "test_helpers.h"
+#include "numx/signal.h"
+
+void test_signal(numxt_ctx_t *ctx)
+{
+    /* ── window_rect ─────────────────────────────────────────────── */
+    suite("signal / window_rect");
+    {
+        numx_real_t w[4];
+        chk_rc(ctx, "rect n=4 rc",     numx_signal_window_rect(4, w),    NUMX_OK);
+        chk_f (ctx, "rect w[0]=1",     w[0], 1.0f, 1e-6f);
+        chk_f (ctx, "rect w[1]=1",     w[1], 1.0f, 1e-6f);
+        chk_f (ctx, "rect w[3]=1",     w[3], 1.0f, 1e-6f);
+
+        numx_real_t w1[1];
+        chk_rc(ctx, "rect n=1 rc",     numx_signal_window_rect(1, w1),   NUMX_OK);
+        chk_f (ctx, "rect n=1 w[0]=1", w1[0], 1.0f, 1e-6f);
+
+        chk_rc(ctx, "rect null",        numx_signal_window_rect(4, NULL), NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "rect n=0",         numx_signal_window_rect(0, w),    NUMX_ERR_INVALID_ARG);
+    }
+
+    /* ── window_hann ─────────────────────────────────────────────── */
+    suite("signal / window_hann");
+    {
+        /* w[i] = 0.5*(1-cos(2*pi*i/(n-1))); n=5 */
+        numx_real_t w[5];
+        chk_rc(ctx, "hann n=5 rc",         numx_signal_window_hann(5, w),    NUMX_OK);
+        chk_f (ctx, "hann w[0]=0 (left)",  w[0], 0.0f, 1e-5f);
+        chk_f (ctx, "hann w[4]=0 (right)", w[4], 0.0f, 1e-5f);
+        chk_f (ctx, "hann w[2]=1 (peak)",  w[2], 1.0f, 1e-5f);
+        chk_f (ctx, "hann symmetric",      w[1], w[3], 1e-6f);
+
+        chk_rc(ctx, "hann null",            numx_signal_window_hann(5, NULL), NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "hann n=0",             numx_signal_window_hann(0, w),    NUMX_ERR_INVALID_ARG);
+    }
+
+    /* ── window_hamming ──────────────────────────────────────────── */
+    suite("signal / window_hamming");
+    {
+        /* w[i] = 0.54 - 0.46*cos(2*pi*i/(n-1)); n=5 */
+        numx_real_t w[5];
+        chk_rc(ctx, "hamming n=5 rc",         numx_signal_window_hamming(5, w),    NUMX_OK);
+        chk_f (ctx, "hamming w[0]=0.08",       w[0], 0.08f, 1e-4f);   /* 0.54-0.46 */
+        chk_f (ctx, "hamming w[2]=1 (peak)",   w[2], 1.0f,  1e-5f);   /* 0.54+0.46 */
+        chk_f (ctx, "hamming symmetric",        w[1], w[3], 1e-6f);
+
+        chk_rc(ctx, "hamming null",             numx_signal_window_hamming(5, NULL), NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "hamming n=0",              numx_signal_window_hamming(0, w),    NUMX_ERR_INVALID_ARG);
+    }
+
+    /* ── window_blackman ─────────────────────────────────────────── */
+    suite("signal / window_blackman");
+    {
+        /* w[i] = 0.42 - 0.5*cos(2pi*i/(n-1)) + 0.08*cos(4pi*i/(n-1)); n=5 */
+        numx_real_t w[5];
+        chk_rc(ctx, "blackman n=5 rc",         numx_signal_window_blackman(5, w),    NUMX_OK);
+        chk_f (ctx, "blackman w[0]≈0",          w[0], 0.0f, 1e-4f);   /* 0.42-0.5+0.08 */
+        chk_f (ctx, "blackman w[2]=1 (peak)",   w[2], 1.0f, 1e-4f);   /* 0.42+0.5+0.08 */
+        chk_f (ctx, "blackman symmetric",        w[1], w[3], 1e-5f);
+
+        chk_rc(ctx, "blackman null",             numx_signal_window_blackman(5, NULL), NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "blackman n=0",              numx_signal_window_blackman(0, w),    NUMX_ERR_INVALID_ARG);
+    }
+
+    /* ── convolve ────────────────────────────────────────────────── */
+    suite("signal / convolve");
+    {
+        /* impulse * h = h (zero-padded to xn+hn-1 = 5) */
+        numx_real_t x[3] = {1,0,0}, h[3] = {1,2,3}, out[5];
+        chk_rc(ctx, "convolve impulse rc",    numx_signal_convolve(x,3,h,3,out), NUMX_OK);
+        chk_f (ctx, "convolve out[0]=1",      out[0], 1.0f, 1e-5f);
+        chk_f (ctx, "convolve out[1]=2",      out[1], 2.0f, 1e-5f);
+        chk_f (ctx, "convolve out[2]=3",      out[2], 3.0f, 1e-5f);
+        chk_f (ctx, "convolve out[3]=0",      out[3], 0.0f, 1e-5f);
+        chk_f (ctx, "convolve out[4]=0",      out[4], 0.0f, 1e-5f);
+
+        /* [1,1] * [1,1] = [1,2,1] */
+        numx_real_t xa[2] = {1,1}, hb[2] = {1,1}, ob[3];
+        numx_signal_convolve(xa,2,hb,2,ob);
+        chk_f (ctx, "convolve [1,1]*[1,1] ob[1]=2", ob[1], 2.0f, 1e-5f);
+
+        chk_rc(ctx, "convolve null-x",        numx_signal_convolve(NULL,3,h,3,out), NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "convolve null-h",        numx_signal_convolve(x,3,NULL,3,out), NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "convolve null-out",      numx_signal_convolve(x,3,h,3,NULL),   NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "convolve xn=0",          numx_signal_convolve(x,0,h,3,out),    NUMX_ERR_INVALID_ARG);
+        chk_rc(ctx, "convolve hn=0",          numx_signal_convolve(x,3,h,0,out),    NUMX_ERR_INVALID_ARG);
+    }
+
+    /* ── correlate ───────────────────────────────────────────────── */
+    suite("signal / correlate");
+    {
+        /* auto-correlation peak at lag-0 (index yn-1 = 2) = sum x[i]^2 = 14 */
+        numx_real_t x[3] = {1,2,3}, out[5];
+        chk_rc(ctx, "correlate auto rc",       numx_signal_correlate(x,3,x,3,out), NUMX_OK);
+        chk_f (ctx, "correlate auto peak=14",  out[2], 14.0f, 1e-4f);
+        chk_f (ctx, "correlate auto symmetric",out[1], out[3], 1e-4f);
+
+        chk_rc(ctx, "correlate null-x",        numx_signal_correlate(NULL,3,x,3,out), NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "correlate null-y",        numx_signal_correlate(x,3,NULL,3,out), NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "correlate null-out",      numx_signal_correlate(x,3,x,3,NULL),   NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "correlate xn=0",          numx_signal_correlate(x,0,x,3,out),    NUMX_ERR_INVALID_ARG);
+    }
+
+    /* ── fir ─────────────────────────────────────────────────────── */
+    suite("signal / fir");
+    {
+        numx_real_t x[4] = {1,2,3,4}, out[4];
+
+        /* identity tap [1]: pass-through */
+        numx_real_t t1[1] = {1.0f};
+        chk_rc(ctx, "fir identity rc",   numx_signal_fir(x,4,t1,1,out), NUMX_OK);
+        chk_f (ctx, "fir identity [0]",  out[0], 1.0f, 1e-5f);
+        chk_f (ctx, "fir identity [2]",  out[2], 3.0f, 1e-5f);
+
+        /* 2-tap box [0.5,0.5]: out[1]=0.5*x[1]+0.5*x[0]=1.5 */
+        numx_real_t t2[2] = {0.5f, 0.5f};
+        numx_signal_fir(x,4,t2,2,out);
+        chk_f (ctx, "fir box out[1]=1.5", out[1], 1.5f, 1e-5f);
+
+        chk_rc(ctx, "fir null-x",         numx_signal_fir(NULL,4,t1,1,out), NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "fir null-taps",       numx_signal_fir(x,4,NULL,1,out), NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "fir null-out",        numx_signal_fir(x,4,t1,1,NULL),  NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "fir xn=0",            numx_signal_fir(x,0,t1,1,out),   NUMX_ERR_INVALID_ARG);
+        chk_rc(ctx, "fir ntaps=0",         numx_signal_fir(x,4,t1,0,out),   NUMX_ERR_INVALID_ARG);
+    }
+
+    /* ── iir_biquad ──────────────────────────────────────────────── */
+    suite("signal / iir_biquad");
+    {
+        numx_real_t x[4] = {1,2,3,4}, out[4];
+
+        /* all-pass: b=[1,0,0], a=[0,0] → H(z)=1, output=input */
+        numx_real_t b[3] = {1,0,0}, a[2] = {0,0};
+        chk_rc(ctx, "biquad all-pass rc",  numx_signal_iir_biquad(x,4,b,a,out), NUMX_OK);
+        chk_f (ctx, "biquad all-pass [0]", out[0], 1.0f, 1e-5f);
+        chk_f (ctx, "biquad all-pass [2]", out[2], 3.0f, 1e-5f);
+
+        chk_rc(ctx, "biquad null-x",       numx_signal_iir_biquad(NULL,4,b,a,out), NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "biquad null-b",       numx_signal_iir_biquad(x,4,NULL,a,out), NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "biquad null-a",       numx_signal_iir_biquad(x,4,b,NULL,out), NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "biquad null-out",     numx_signal_iir_biquad(x,4,b,a,NULL),   NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "biquad n=0",          numx_signal_iir_biquad(x,0,b,a,out),    NUMX_ERR_INVALID_ARG);
+    }
+
+    /* ── peaks ───────────────────────────────────────────────────── */
+    suite("signal / peaks");
+    {
+        /* [1,3,1,2,1] → peaks at indices 1 and 3 */
+        numx_real_t xp[5] = {1,3,1,2,1};
+        numx_size_t pk[4], np;
+        chk_rc(ctx, "peaks 2-peak rc",     numx_signal_peaks(xp,5,pk,4,&np), NUMX_OK);
+        chk_true(ctx, "peaks count=2",     np == 2);
+        chk_true(ctx, "peaks pk[0]=1",     pk[0] == 1);
+        chk_true(ctx, "peaks pk[1]=3",     pk[1] == 3);
+
+        /* monotone increasing: no peaks */
+        numx_real_t xm[4] = {1,2,3,4};
+        numx_signal_peaks(xm,4,pk,4,&np);
+        chk_true(ctx, "peaks monotone=0",  np == 0);
+
+        /* n<3: no peaks regardless */
+        numx_real_t xs[2] = {2,1};
+        numx_signal_peaks(xs,2,pk,4,&np);
+        chk_true(ctx, "peaks n=2 → 0",    np == 0);
+
+        chk_rc(ctx, "peaks null-x",        numx_signal_peaks(NULL,5,pk,4,&np), NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "peaks null-peaks",    numx_signal_peaks(xp,5,NULL,4,&np), NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "peaks null-npeaks",   numx_signal_peaks(xp,5,pk,4,NULL),  NUMX_ERR_NULL_PTR);
+    }
+
+    /* ── ema ─────────────────────────────────────────────────────── */
+    suite("signal / ema");
+    {
+        numx_real_t x[3] = {1,3,2}, out[3];
+
+        /* alpha=1: out[i]=x[i] */
+        chk_rc(ctx, "ema alpha=1 rc",    numx_signal_ema(x,3,1.0f,out), NUMX_OK);
+        chk_f (ctx, "ema alpha=1 [0]=1", out[0], 1.0f, 1e-5f);
+        chk_f (ctx, "ema alpha=1 [1]=3", out[1], 3.0f, 1e-5f);
+        chk_f (ctx, "ema alpha=1 [2]=2", out[2], 2.0f, 1e-5f);
+
+        /* alpha=0: out[i]=x[0] for all i */
+        numx_signal_ema(x,3,0.0f,out);
+        chk_f (ctx, "ema alpha=0 [1]=1", out[1], 1.0f, 1e-5f);
+        chk_f (ctx, "ema alpha=0 [2]=1", out[2], 1.0f, 1e-5f);
+
+        /* alpha=0.5: [1,2,3] → [1, 1.5, 2.25] */
+        numx_real_t xa[3] = {1,2,3};
+        numx_signal_ema(xa,3,0.5f,out);
+        chk_f (ctx, "ema alpha=0.5 [0]=1.0",  out[0], 1.0f,  1e-5f);
+        chk_f (ctx, "ema alpha=0.5 [1]=1.5",  out[1], 1.5f,  1e-5f);
+        chk_f (ctx, "ema alpha=0.5 [2]=2.25", out[2], 2.25f, 1e-5f);
+
+        chk_rc(ctx, "ema null-x",    numx_signal_ema(NULL,3,0.5f,out), NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "ema null-out",  numx_signal_ema(x,3,0.5f,NULL),   NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "ema n=0",       numx_signal_ema(x,0,0.5f,out),    NUMX_ERR_INVALID_ARG);
+        chk_rc(ctx, "ema alpha<0",   numx_signal_ema(x,3,-0.1f,out),   NUMX_ERR_INVALID_ARG);
+        chk_rc(ctx, "ema alpha>1",   numx_signal_ema(x,3,1.1f,out),    NUMX_ERR_INVALID_ARG);
+    }
+}

--- a/tests/esp32_tests/test_sketch.c
+++ b/tests/esp32_tests/test_sketch.c
@@ -1,0 +1,74 @@
+#include "test_helpers.h"
+#include "numx/sketch.h"
+
+void test_sketch(numxt_ctx_t *ctx)
+{
+    /* ── rsvd: rank-1 diagonal matrix ───────────────────────────── */
+    suite("sketch / rsvd_rank1");
+    {
+        /*
+         * A = diag(2,0,0) as 3×3: only one non-zero singular value σ_1=2.
+         * rank=1, oversample=2 → (rank+oversample)=3 ≤ min(3,3).
+         * S[0] should converge to 2.0 regardless of random seed.
+         */
+        numx_real_t A[9] = {2,0,0, 0,0,0, 0,0,0};
+        numx_real_t U[3], S[1], Vt[3]; /* U: 3×1, Vt: 1×3 */
+
+        chk_rc  (ctx, "rsvd rank1 rc",
+                 numx_sketch_rsvd(A, 3, 3, 1, 2, 1u, U, S, Vt), NUMX_OK);
+        chk_true(ctx, "rsvd rank1 S[0]>0",  S[0] > 0.0f);
+        chk_f   (ctx, "rsvd rank1 S[0]≈2",  S[0], 2.0f, 0.1f);
+    }
+
+    /* ── rsvd: rank-2 diagonal — singular values descending ──────── */
+    suite("sketch / rsvd_rank2");
+    {
+        /*
+         * A = diag(4,2,0,0) as 4×4: σ_1=4, σ_2=2.
+         * rank=2, oversample=2 → (rank+oversample)=4 ≤ min(4,4).
+         */
+        numx_real_t A[16] = {4,0,0,0, 0,2,0,0, 0,0,0,0, 0,0,0,0};
+        numx_real_t U[8], S[2], Vt[8]; /* U: 4×2, Vt: 2×4 */
+
+        chk_rc  (ctx, "rsvd rank2 rc",
+                 numx_sketch_rsvd(A, 4, 4, 2, 2, 1u, U, S, Vt), NUMX_OK);
+        chk_true(ctx, "rsvd rank2 S[0]>S[1]", S[0] >= S[1]);
+        chk_true(ctx, "rsvd rank2 S[1]>=0",   S[1] >= 0.0f);
+        chk_f   (ctx, "rsvd rank2 S[0]≈4",    S[0], 4.0f, 0.2f);
+        chk_f   (ctx, "rsvd rank2 S[1]≈2",    S[1], 2.0f, 0.2f);
+    }
+
+    /* ── rsvd: seed=0 (internally becomes 1) ────────────────────── */
+    suite("sketch / rsvd_seed0");
+    {
+        numx_real_t A[4] = {3,0, 0,1}; /* 2×2 diagonal */
+        numx_real_t U[2], S[1], Vt[2];
+
+        chk_rc  (ctx, "rsvd seed=0 rc",
+                 numx_sketch_rsvd(A, 2, 2, 1, 1, 0u, U, S, Vt), NUMX_OK);
+        chk_true(ctx, "rsvd seed=0 S[0]>0", S[0] > 0.0f);
+        chk_f   (ctx, "rsvd seed=0 S[0]≈3", S[0], 3.0f, 0.15f);
+    }
+
+    /* ── rsvd: error cases ───────────────────────────────────────── */
+    suite("sketch / rsvd_errors");
+    {
+        numx_real_t A[4] = {1,0, 0,1};
+        numx_real_t U[2], S[1], Vt[2];
+
+        chk_rc(ctx, "rsvd null-A",
+               numx_sketch_rsvd(NULL, 2, 2, 1, 0, 1u, U, S, Vt),  NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "rsvd null-U",
+               numx_sketch_rsvd(A, 2, 2, 1, 0, 1u, NULL, S, Vt),  NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "rsvd null-S",
+               numx_sketch_rsvd(A, 2, 2, 1, 0, 1u, U, NULL, Vt),  NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "rsvd null-Vt",
+               numx_sketch_rsvd(A, 2, 2, 1, 0, 1u, U, S, NULL),   NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "rsvd m=0",
+               numx_sketch_rsvd(A, 0, 2, 1, 0, 1u, U, S, Vt),     NUMX_ERR_INVALID_ARG);
+        chk_rc(ctx, "rsvd n=0",
+               numx_sketch_rsvd(A, 2, 0, 1, 0, 1u, U, S, Vt),     NUMX_ERR_INVALID_ARG);
+        chk_rc(ctx, "rsvd rank=0",
+               numx_sketch_rsvd(A, 2, 2, 0, 0, 1u, U, S, Vt),     NUMX_ERR_INVALID_ARG);
+    }
+}

--- a/tests/esp32_tests/test_stats.c
+++ b/tests/esp32_tests/test_stats.c
@@ -1,0 +1,109 @@
+#include "test_helpers.h"
+#include "numx/stats.h"
+
+void test_stats(numxt_ctx_t *ctx)
+{
+    numx_real_t r;
+
+    suite("stats / mean");
+    {
+        numx_real_t a5[5]={1,2,3,4,5};
+        chk_rc(ctx, "mean rc", numx_stats_mean(a5,5,&r), NUMX_OK);
+        chk_f (ctx,"mean [1..5]=3",      r, 3.0f, 1e-5f);
+
+        numx_real_t neg[4]={-3,-1,1,3};
+        numx_stats_mean(neg,4,&r);
+        chk_f (ctx,"mean negatives=0",   r, 0.0f, 1e-5f);
+
+        numx_real_t c4[4]={5,5,5,5};
+        numx_stats_mean(c4,4,&r);
+        chk_f (ctx,"mean constant=5",    r, 5.0f, 1e-5f);
+
+        numx_real_t a7[7]={1,2,3,4,5,6,7};
+        numx_stats_mean(a7,7,&r);
+        chk_f (ctx,"mean arith-seq [1..7]=4",  r, 4.0f, 1e-5f);
+
+        numx_real_t s1[1]={42};
+        numx_stats_mean(s1,1,&r);
+        chk_f (ctx,"mean n=1=42",        r, 42.0f,1e-5f);
+
+        chk_rc(ctx, "mean null-a",   numx_stats_mean(NULL,3,&r),  NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "mean null-out", numx_stats_mean(a5,5,NULL),  NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "mean n=0",      numx_stats_mean(a5,0,&r),    NUMX_ERR_INVALID_ARG);
+    }
+
+    suite("stats / variance");
+    {
+        numx_real_t d[8]={2,4,4,4,5,5,7,9};
+        chk_rc(ctx, "var pop rc", numx_stats_variance(d,8,NUMX_VAR_POPULATION,&r), NUMX_OK);
+        chk_f (ctx,"var pop=4",       r, 4.0f,           1e-4f);
+
+        chk_rc(ctx, "var samp rc", numx_stats_variance(d,8,NUMX_VAR_SAMPLE,&r), NUMX_OK);
+        chk_f (ctx,"var sample=32/7", r, 32.0f/7.0f,     1e-3f);
+
+        numx_real_t c4[4]={7,7,7,7};
+        numx_stats_variance(c4,4,NUMX_VAR_POPULATION,&r);
+        chk_f (ctx,"var constant=0",  r, 0.0f,            1e-5f);
+
+        numx_real_t a5[5]={1,2,3,4,5};
+        numx_real_t rp, rs;
+        numx_stats_variance(a5,5,NUMX_VAR_POPULATION,&rp);
+        numx_stats_variance(a5,5,NUMX_VAR_SAMPLE,&rs);
+        chk_true(ctx, "var sample > population", rs > rp);
+
+        chk_rc(ctx, "var sample n=1 rejected",
+               numx_stats_variance(a5,1,NUMX_VAR_SAMPLE,&r), NUMX_ERR_INVALID_ARG);
+        chk_rc(ctx, "var null-a",  numx_stats_variance(NULL,4,NUMX_VAR_POPULATION,&r), NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "var null-out",numx_stats_variance(d,8,NUMX_VAR_POPULATION,NULL),  NUMX_ERR_NULL_PTR);
+    }
+
+    suite("stats / median");
+    {
+        numx_real_t odd[5]={5,3,1,4,2};
+        chk_rc(ctx, "median odd rc", numx_stats_median(odd,5,&r), NUMX_OK);
+        chk_f (ctx,"median odd=3",    r, 3.0f, 1e-5f);
+
+        numx_real_t even[4]={4,1,3,2};
+        numx_stats_median(even,4,&r);
+        chk_f (ctx,"median even=2.5", r, 2.5f, 1e-5f);
+
+        numx_real_t inp[3]={5,3,1};
+        numx_stats_median(inp,3,&r);
+        chk_f (ctx,"median no-modify [0]", inp[0], 5.0f, 1e-6f);
+        chk_f (ctx,"median no-modify [1]", inp[1], 3.0f, 1e-6f);
+        chk_f (ctx,"median no-modify [2]", inp[2], 1.0f, 1e-6f);
+
+        numx_real_t sorted5[5]={10,20,30,40,50};
+        numx_stats_median(sorted5,5,&r);
+        chk_f (ctx,"median sorted-mid=30",       r, 30.0f,1e-5f);
+
+        numx_real_t s1[1]={7};
+        numx_stats_median(s1,1,&r);
+        chk_f (ctx,"median n=1=7",  r, 7.0f, 1e-5f);
+
+        numx_real_t s2[2]={3,1};
+        numx_stats_median(s2,2,&r);
+        chk_f (ctx,"median n=2=2",  r, 2.0f, 1e-5f);
+
+        chk_rc(ctx, "median null-a",  numx_stats_median(NULL,3,&r), NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "median null-out",numx_stats_median(odd,5,NULL),NUMX_ERR_NULL_PTR);
+    }
+
+    suite("stats / percentile");
+    {
+        numx_real_t a[5]={5,3,1,4,2};
+        chk_rc(ctx, "pct p0 rc", numx_stats_percentile(a,5,0.0f,&r),   NUMX_OK);
+        chk_f (ctx,"pct p0=min=1",  r, 1.0f, 1e-5f);
+        numx_stats_percentile(a,5,100.0f,&r);
+        chk_f (ctx,"pct p100=max=5",r, 5.0f, 1e-5f);
+
+        numx_real_t inp[3]={3,1,2};
+        numx_stats_percentile(inp,3,50.0f,&r);
+        chk_f (ctx,"pct no-modify [0]", inp[0], 3.0f, 1e-6f);
+
+        chk_rc(ctx, "pct null-a",  numx_stats_percentile(NULL,3,50.0f,&r), NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "pct null-out",numx_stats_percentile(a,5,50.0f,NULL),  NUMX_ERR_NULL_PTR);
+        chk_rc(ctx, "pct p<0",     numx_stats_percentile(a,5,-1.0f,&r),    NUMX_ERR_INVALID_ARG);
+        chk_rc(ctx, "pct p>100",   numx_stats_percentile(a,5,101.0f,&r),   NUMX_ERR_INVALID_ARG);
+    }
+}

--- a/tests/esp32_tests/tests.h
+++ b/tests/esp32_tests/tests.h
@@ -1,0 +1,20 @@
+#ifndef NUMX_TESTS_H
+#define NUMX_TESTS_H
+
+#include "test_helpers.h"
+
+void test_linalg(numxt_ctx_t *ctx);
+void test_stats(numxt_ctx_t *ctx);
+void test_roots(numxt_ctx_t *ctx);
+void test_integrate(numxt_ctx_t *ctx);
+void test_differentiate(numxt_ctx_t *ctx);
+void test_interpolate(numxt_ctx_t *ctx);
+void test_poly(numxt_ctx_t *ctx);
+void test_ode(numxt_ctx_t *ctx);
+void test_signal(numxt_ctx_t *ctx);
+void test_fft(numxt_ctx_t *ctx);
+void test_autodiff(numxt_ctx_t *ctx);
+void test_compressed_sensing(numxt_ctx_t *ctx);
+void test_sketch(numxt_ctx_t *ctx);
+
+#endif /* NUMX_TESTS_H */

--- a/tests/x64/CMakeLists.txt
+++ b/tests/x64/CMakeLists.txt
@@ -1,0 +1,106 @@
+cmake_minimum_required(VERSION 3.15)
+project(numx_tests_x64 C)
+
+# Host-native float64 tests — NOT for ESP32.
+# numx_real_t = double (NUMX_USE_DOUBLE is set for both library and tests).
+# Requires a 64-bit toolchain (default on modern systems).
+
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+
+set(NUMX_INC  ${CMAKE_CURRENT_SOURCE_DIR}/../../include)
+set(NUMX_SRC  ${CMAKE_CURRENT_SOURCE_DIR}/../../src)
+set(UNITY_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../unity)
+
+if(MSVC)
+    add_compile_options(/W3 /wd4100)
+else()
+    add_compile_options(-Wall -Wextra -Wno-unused-parameter)
+endif()
+
+# numx library — float64 (NUMX_USE_DOUBLE enables double precision throughout)
+file(GLOB NUMX_SRCS ${NUMX_SRC}/*.c)
+add_library(numx_f64 STATIC ${NUMX_SRCS})
+target_include_directories(numx_f64 PUBLIC ${NUMX_INC})
+target_compile_definitions(numx_f64 PUBLIC NUMX_USE_DOUBLE)
+
+enable_testing()
+
+# ── Per-module executables ────────────────────────────────────────────────────
+# Each generates a tiny main() stub so the module can be run in isolation.
+# Build one:   cmake --build . --target numx_test_x64_linalg
+# Run one:     ./numx_test_x64_linalg          (Linux/macOS)
+#              numx_test_x64_linalg.exe         (Windows)
+# Via CTest:   ctest -R linalg
+
+function(add_numx_module_test MODULE)
+    set(STUB "${CMAKE_CURRENT_BINARY_DIR}/runner_${MODULE}.c")
+    file(WRITE ${STUB}
+        "#include \"unity.h\"\n"
+        "void numx_test_${MODULE}(void);\n"
+        "void setUp(void){}\n"
+        "void tearDown(void){}\n"
+        "int main(void){UNITY_BEGIN();numx_test_${MODULE}();return UNITY_END();}\n"
+    )
+    add_executable(numx_test_x64_${MODULE}
+        ${UNITY_DIR}/unity.c
+        test_${MODULE}.c
+        ${STUB}
+    )
+    target_include_directories(numx_test_x64_${MODULE} PRIVATE ${NUMX_INC} ${UNITY_DIR})
+    target_compile_definitions(numx_test_x64_${MODULE} PRIVATE NUMX_USE_DOUBLE UNITY_INCLUDE_DOUBLE)
+    if(UNIX)
+        target_link_libraries(numx_test_x64_${MODULE} numx_f64 m)
+    else()
+        target_link_libraries(numx_test_x64_${MODULE} numx_f64)
+    endif()
+    add_test(NAME numx_x64_${MODULE} COMMAND numx_test_x64_${MODULE})
+endfunction()
+
+set(NUMX_MODULES
+    linalg stats roots integrate differentiate
+    interpolate poly ode signal fft
+    autodiff compressed_sensing sketch
+)
+foreach(MOD ${NUMX_MODULES})
+    add_numx_module_test(${MOD})
+endforeach()
+
+# ── Full suite (all modules in one run) ──────────────────────────────────────
+add_executable(numx_test_x64
+    ${UNITY_DIR}/unity.c
+    test_runner.c
+    test_linalg.c
+    test_stats.c
+    test_roots.c
+    test_integrate.c
+    test_differentiate.c
+    test_interpolate.c
+    test_poly.c
+    test_ode.c
+    test_signal.c
+    test_fft.c
+    test_autodiff.c
+    test_compressed_sensing.c
+    test_sketch.c
+)
+target_include_directories(numx_test_x64 PRIVATE ${NUMX_INC} ${UNITY_DIR})
+target_compile_definitions(numx_test_x64 PRIVATE NUMX_USE_DOUBLE UNITY_INCLUDE_DOUBLE)
+if(UNIX)
+    target_link_libraries(numx_test_x64 numx_f64 m)
+else()
+    target_link_libraries(numx_test_x64 numx_f64)
+endif()
+add_test(NAME numx_x64 COMMAND numx_test_x64)
+
+# ── Windows performance benchmark (float64) ──────────────────────────────────
+add_executable(numx_bench_x64
+    ${CMAKE_CURRENT_SOURCE_DIR}/../bench_win.c
+)
+target_include_directories(numx_bench_x64 PRIVATE ${NUMX_INC})
+target_compile_definitions(numx_bench_x64 PRIVATE NUMX_USE_DOUBLE)
+if(UNIX)
+    target_link_libraries(numx_bench_x64 numx_f64 m)
+else()
+    target_link_libraries(numx_bench_x64 numx_f64)
+endif()

--- a/tests/x64/test_autodiff.c
+++ b/tests/x64/test_autodiff.c
@@ -1,0 +1,286 @@
+/**
+ * @file test_autodiff.c
+ * @brief Autodiff tests — float64 / x64 host build.
+ *        numx_real_t = double  (compiled with -DNUMX_USE_DOUBLE)
+ */
+
+#include "unity.h"
+#include "numx/autodiff.h"
+
+#define TOL       1e-6
+#define TOL_TIGHT 1e-10
+
+/* ── Forward-mode ───────────────────────────────────────────────────── */
+
+void test_dual_const(void)
+{
+    numx_dual_t c = numx_dual_const(5.0);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 5.0, c.re);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 0.0, c.du);
+}
+
+void test_dual_var(void)
+{
+    numx_dual_t v = numx_dual_var(3.0);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 3.0, v.re);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 1.0, v.du);
+}
+
+void test_dual_add(void)
+{
+    numx_dual_t r = numx_dual_add(numx_dual_var(2.0), numx_dual_const(3.0));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 5.0, r.re);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 1.0, r.du);
+}
+
+void test_dual_sub(void)
+{
+    numx_dual_t r = numx_dual_sub(numx_dual_var(5.0), numx_dual_const(3.0));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 2.0, r.re);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 1.0, r.du);
+}
+
+void test_dual_mul(void)
+{
+    numx_dual_t a = numx_dual_var(3.0);
+    numx_dual_t r = numx_dual_mul(a, a);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 9.0, r.re);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 6.0, r.du);
+}
+
+void test_dual_div(void)
+{
+    numx_dual_t r = numx_dual_div(numx_dual_var(6.0), numx_dual_const(3.0));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 2.0,       r.re);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 1.0/3.0,   r.du);
+}
+
+void test_dual_neg(void)
+{
+    numx_dual_t r = numx_dual_neg(numx_dual_var(3.0));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, -3.0, r.re);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, -1.0, r.du);
+}
+
+void test_dual_sin(void)
+{
+    numx_dual_t r = numx_dual_sin(numx_dual_var(0.0));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 0.0, r.re);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 1.0, r.du);
+}
+
+void test_dual_cos(void)
+{
+    numx_dual_t r = numx_dual_cos(numx_dual_var(0.0));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 1.0, r.re);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 0.0, r.du);
+}
+
+void test_dual_exp(void)
+{
+    numx_dual_t r = numx_dual_exp(numx_dual_var(0.0));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 1.0, r.re);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 1.0, r.du);
+}
+
+void test_dual_log(void)
+{
+    numx_dual_t r = numx_dual_log(numx_dual_var(1.0));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 0.0, r.re);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 1.0, r.du);
+}
+
+void test_dual_sqrt(void)
+{
+    numx_dual_t r = numx_dual_sqrt(numx_dual_var(4.0));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 2.0,  r.re);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 0.25, r.du);
+}
+
+void test_dual_chain_quadratic(void)
+{
+    numx_dual_t x  = numx_dual_var(3.0);
+    numx_dual_t r  = numx_dual_add(numx_dual_mul(x, x), numx_dual_const(5.0));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 14.0, r.re);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT,  6.0, r.du);
+}
+
+void test_dual_div_by_zero(void)
+{
+    numx_dual_t r = numx_dual_div(numx_dual_var(1.0), numx_dual_const(0.0));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 0.0, r.re);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 0.0, r.du);
+}
+
+void test_dual_log_nonpositive(void)
+{
+    numx_dual_t r = numx_dual_log(numx_dual_var(0.0));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 0.0, r.re);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 0.0, r.du);
+}
+
+void test_dual_sqrt_negative(void)
+{
+    numx_dual_t r = numx_dual_sqrt(numx_dual_var(-4.0));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 0.0, r.re);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 0.0, r.du);
+}
+
+/* ── Reverse-mode ───────────────────────────────────────────────────── */
+
+void test_ad_init(void)
+{
+    numx_ad_tape_t tape;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_ad_init(&tape));
+    TEST_ASSERT_EQUAL_UINT32(0, tape.len);
+}
+
+void test_ad_var(void)
+{
+    numx_ad_tape_t tape; numx_size_t ix;
+    numx_ad_init(&tape);
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_ad_var(&tape, 5.0, &ix));
+    TEST_ASSERT_EQUAL_UINT32(0, ix);
+    TEST_ASSERT_EQUAL_UINT32(1, tape.len);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 5.0, numx_ad_val(&tape, ix));
+}
+
+void test_ad_add_backward(void)
+{
+    numx_ad_tape_t tape; numx_size_t xi, yi, zi;
+    numx_ad_init(&tape);
+    numx_ad_var(&tape, 3.0, &xi);
+    numx_ad_var(&tape, 4.0, &yi);
+    numx_ad_add(&tape, xi, yi, &zi);
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_ad_backward(&tape, zi));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 7.0, numx_ad_val(&tape, zi));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 1.0, numx_ad_grad(&tape, xi));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 1.0, numx_ad_grad(&tape, yi));
+}
+
+void test_ad_mul_backward(void)
+{
+    numx_ad_tape_t tape; numx_size_t xi, yi, zi;
+    numx_ad_init(&tape);
+    numx_ad_var(&tape, 3.0, &xi);
+    numx_ad_var(&tape, 4.0, &yi);
+    numx_ad_mul(&tape, xi, yi, &zi);
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_ad_backward(&tape, zi));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 12.0, numx_ad_val(&tape, zi));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT,  4.0, numx_ad_grad(&tape, xi));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT,  3.0, numx_ad_grad(&tape, yi));
+}
+
+void test_ad_div_backward(void)
+{
+    numx_ad_tape_t tape; numx_size_t xi, yi, zi;
+    numx_ad_init(&tape);
+    numx_ad_var(&tape, 6.0, &xi);
+    numx_ad_var(&tape, 2.0, &yi);
+    numx_ad_div(&tape, xi, yi, &zi);
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_ad_backward(&tape, zi));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT,  0.5, numx_ad_grad(&tape, xi));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, -1.5, numx_ad_grad(&tape, yi));
+}
+
+void test_ad_sin_backward(void)
+{
+    numx_ad_tape_t tape; numx_size_t xi, zi;
+    numx_ad_init(&tape);
+    numx_ad_var(&tape, 0.0, &xi);
+    numx_ad_sin(&tape, xi, &zi);
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_ad_backward(&tape, zi));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 1.0, numx_ad_grad(&tape, xi));
+}
+
+void test_ad_quadratic(void)
+{
+    numx_ad_tape_t tape; numx_size_t xi, yi, x2i, y2i, zi;
+    numx_ad_init(&tape);
+    numx_ad_var(&tape, 3.0, &xi);
+    numx_ad_var(&tape, 4.0, &yi);
+    numx_ad_mul(&tape, xi, xi, &x2i);
+    numx_ad_mul(&tape, yi, yi, &y2i);
+    numx_ad_add(&tape, x2i, y2i, &zi);
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_ad_backward(&tape, zi));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 25.0, numx_ad_val(&tape, zi));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT,  6.0, numx_ad_grad(&tape, xi));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT,  8.0, numx_ad_grad(&tape, yi));
+}
+
+void test_ad_null_returns_error(void)
+{
+    numx_ad_tape_t tape; numx_size_t ix;
+    numx_ad_init(&tape);
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_ad_init(NULL));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_ad_var(NULL, 1.0, &ix));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_ad_var(&tape, 1.0, NULL));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_ad_backward(NULL, 0));
+}
+
+void test_ad_invalid_idx_returns_error(void)
+{
+    numx_ad_tape_t tape; numx_size_t xi, zi;
+    numx_ad_init(&tape);
+    numx_ad_var(&tape, 1.0, &xi);
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_ad_backward(&tape, 999));
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_ad_add(&tape, 0, 999, &zi));
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_ad_neg(&tape, 999, &zi));
+}
+
+void test_ad_div_by_zero_returns_error(void)
+{
+    numx_ad_tape_t tape; numx_size_t xi, yi, zi;
+    numx_ad_init(&tape);
+    numx_ad_var(&tape, 6.0, &xi);
+    numx_ad_var(&tape, 0.0, &yi);
+    TEST_ASSERT_EQUAL(NUMX_ERR_SINGULAR, numx_ad_div(&tape, xi, yi, &zi));
+}
+
+void test_ad_log_nonpositive_returns_error(void)
+{
+    numx_ad_tape_t tape; numx_size_t xi, zi;
+    numx_ad_init(&tape);
+    numx_ad_var(&tape, 0.0, &xi);
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_ad_log(&tape, xi, &zi));
+}
+
+void test_ad_sqrt_negative_returns_error(void)
+{
+    numx_ad_tape_t tape; numx_size_t xi, zi;
+    numx_ad_init(&tape);
+    numx_ad_var(&tape, -1.0, &xi);
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_ad_sqrt(&tape, xi, &zi));
+}
+
+void numx_test_autodiff(void)
+{
+    RUN_TEST(test_dual_const);
+    RUN_TEST(test_dual_var);
+    RUN_TEST(test_dual_add);
+    RUN_TEST(test_dual_sub);
+    RUN_TEST(test_dual_mul);
+    RUN_TEST(test_dual_div);
+    RUN_TEST(test_dual_neg);
+    RUN_TEST(test_dual_sin);
+    RUN_TEST(test_dual_cos);
+    RUN_TEST(test_dual_exp);
+    RUN_TEST(test_dual_log);
+    RUN_TEST(test_dual_sqrt);
+    RUN_TEST(test_dual_chain_quadratic);
+    RUN_TEST(test_dual_div_by_zero);
+    RUN_TEST(test_dual_log_nonpositive);
+    RUN_TEST(test_dual_sqrt_negative);
+    RUN_TEST(test_ad_init);
+    RUN_TEST(test_ad_var);
+    RUN_TEST(test_ad_add_backward);
+    RUN_TEST(test_ad_mul_backward);
+    RUN_TEST(test_ad_div_backward);
+    RUN_TEST(test_ad_sin_backward);
+    RUN_TEST(test_ad_quadratic);
+    RUN_TEST(test_ad_null_returns_error);
+    RUN_TEST(test_ad_invalid_idx_returns_error);
+    RUN_TEST(test_ad_div_by_zero_returns_error);
+    RUN_TEST(test_ad_log_nonpositive_returns_error);
+    RUN_TEST(test_ad_sqrt_negative_returns_error);
+}

--- a/tests/x64/test_compressed_sensing.c
+++ b/tests/x64/test_compressed_sensing.c
@@ -1,0 +1,176 @@
+/**
+ * @file test_compressed_sensing.c
+ * @brief Compressed sensing tests — float64 / x64 host build.
+ *        numx_real_t = double  (compiled with -DNUMX_USE_DOUBLE)
+ */
+
+#include "unity.h"
+#include "numx/compressed_sensing.h"
+
+#define TOL       1e-6
+#define TOL_TIGHT 1e-9
+
+void test_omp_identity_1sparse(void)
+{
+    numx_real_t A[16] = {1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1};
+    numx_real_t y[4]  = {1.0,0.0,0.0,0.0};
+    numx_real_t x[4]  = {0};
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_cs_omp(A, y, 4, 4, 1, x));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 1.0, x[0]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 0.0, x[1]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 0.0, x[2]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 0.0, x[3]);
+}
+
+void test_omp_identity_2sparse(void)
+{
+    numx_real_t A[16] = {1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1};
+    numx_real_t y[4]  = {0.0,1.0,0.0,1.0};
+    numx_real_t x[4]  = {0};
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_cs_omp(A, y, 4, 4, 2, x));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 0.0, x[0]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 1.0, x[1]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 0.0, x[2]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 1.0, x[3]);
+}
+
+void test_omp_overdetermined_1sparse(void)
+{
+    numx_real_t A[6] = {1,0, 0,1, 1,1};
+    numx_real_t y[3] = {2.0,0.0,2.0};
+    numx_real_t x[2] = {0};
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_cs_omp(A, y, 3, 2, 1, x));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 2.0, x[0]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 0.0, x[1]);
+}
+
+void test_omp_null_returns_error(void)
+{
+    numx_real_t A[4]={0},y[2]={0},x[2]={0};
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_cs_omp(NULL,y,2,2,1,x));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_cs_omp(A,NULL,2,2,1,x));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_cs_omp(A,y,2,2,1,NULL));
+}
+
+void test_omp_invalid_arg_returns_error(void)
+{
+    numx_real_t A[4]={0},y[2]={0},x[2]={0};
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_cs_omp(A,y,2,2,3,x));
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_cs_omp(A,y,0,2,1,x));
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_cs_omp(A,y,2,2,0,x));
+}
+
+void test_ista_identity_shrinkage(void)
+{
+    numx_real_t A[16] = {1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1};
+    numx_real_t y[4]  = {1.0,0.0,0.0,0.0};
+    numx_real_t x[4]  = {0};
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_cs_ista(A, y, 4, 4, 0.1, 1.0, 10, x));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 0.9, x[0]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 0.0, x[1]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 0.0, x[2]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 0.0, x[3]);
+}
+
+void test_ista_zero_lambda_recovery(void)
+{
+    numx_real_t A[16] = {1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1};
+    numx_real_t y[4]  = {1.0,0.0,0.0,0.0};
+    numx_real_t x[4]  = {0};
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_cs_ista(A, y, 4, 4, 0.0, 0.9, 100, x));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 1.0, x[0]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 0.0, x[1]);
+}
+
+void test_ista_large_lambda_zeros(void)
+{
+    numx_real_t A[16] = {1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1};
+    numx_real_t y[4]  = {1.0,0.0,0.0,0.0};
+    numx_real_t x[4]  = {0};
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_cs_ista(A, y, 4, 4, 2.0, 1.0, 20, x));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 0.0, x[0]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 0.0, x[1]);
+}
+
+void test_ista_null_returns_error(void)
+{
+    numx_real_t A[4]={0},y[2]={0},x[2]={0};
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_cs_ista(NULL,y,2,2,0.1,1.0,10,x));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_cs_ista(A,NULL,2,2,0.1,1.0,10,x));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_cs_ista(A,y,2,2,0.1,1.0,10,NULL));
+}
+
+void test_ista_invalid_step_returns_error(void)
+{
+    numx_real_t A[4]={0},y[2]={0},x[2]={0};
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_cs_ista(A,y,2,2,0.1,0.0,10,x));
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_cs_ista(A,y,2,2,-0.1,1.0,10,x));
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_cs_ista(A,y,0,2,0.1,1.0,10,x));
+}
+
+void test_spectral_norm_identity(void)
+{
+    numx_real_t A[16] = {1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1};
+    numx_real_t sigma;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_cs_spectral_norm(A, 4, 4, 32, &sigma));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 1.0, sigma);
+}
+
+void test_spectral_norm_scaled_identity(void)
+{
+    numx_real_t A[16] = {3,0,0,0, 0,3,0,0, 0,0,3,0, 0,0,0,3};
+    numx_real_t sigma;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_cs_spectral_norm(A, 4, 4, 32, &sigma));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 3.0, sigma);
+}
+
+void test_spectral_norm_tall_matrix(void)
+{
+    numx_real_t A[6] = {1,0, 0,1, 0,0};
+    numx_real_t sigma;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_cs_spectral_norm(A, 3, 2, 32, &sigma));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 1.0, sigma);
+}
+
+void test_spectral_norm_null_returns_error(void)
+{
+    numx_real_t A[4]={0},sigma;
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_cs_spectral_norm(NULL,2,2,32,&sigma));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_cs_spectral_norm(A,2,2,32,NULL));
+}
+
+void test_spectral_norm_invalid_arg(void)
+{
+    numx_real_t A[4]={0},sigma;
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_cs_spectral_norm(A,0,2,32,&sigma));
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_cs_spectral_norm(A,2,0,32,&sigma));
+}
+
+void numx_test_compressed_sensing(void)
+{
+    RUN_TEST(test_omp_identity_1sparse);
+    RUN_TEST(test_omp_identity_2sparse);
+    RUN_TEST(test_omp_overdetermined_1sparse);
+    RUN_TEST(test_omp_null_returns_error);
+    RUN_TEST(test_omp_invalid_arg_returns_error);
+    RUN_TEST(test_ista_identity_shrinkage);
+    RUN_TEST(test_ista_zero_lambda_recovery);
+    RUN_TEST(test_ista_large_lambda_zeros);
+    RUN_TEST(test_ista_null_returns_error);
+    RUN_TEST(test_ista_invalid_step_returns_error);
+    RUN_TEST(test_spectral_norm_identity);
+    RUN_TEST(test_spectral_norm_scaled_identity);
+    RUN_TEST(test_spectral_norm_tall_matrix);
+    RUN_TEST(test_spectral_norm_null_returns_error);
+    RUN_TEST(test_spectral_norm_invalid_arg);
+}

--- a/tests/x64/test_differentiate.c
+++ b/tests/x64/test_differentiate.c
@@ -1,0 +1,188 @@
+/**
+ * @file test_differentiate.c
+ * @brief Differentiation tests — float64 / x64 host build.
+ *        numx_real_t = double  (compiled with -DNUMX_USE_DOUBLE)
+ *
+ * With h=1e-5 and double precision:
+ *   forward  O(h)    — truncation ~1e-5, TOL_FWD=1e-3
+ *   central  O(h^2)  — truncation ~1e-10, TOL_CTR=1e-8
+ *   Richardson O(h^4)— ~1e-18, limited by round-off, TOL_RICH=1e-9
+ */
+
+#include "unity.h"
+#include "numx/numx_types.h"
+#include "numx/differentiate.h"
+
+#define TOL_FWD  1e-3
+#define TOL_CTR  1e-8
+#define TOL_RICH 1e-9
+
+static const numx_real_t H = 1e-5;
+
+static numx_real_t f_quad(numx_real_t x)  { return x*x; }
+static numx_real_t f_cubic(numx_real_t x) { return x*x*x; }
+static numx_real_t f_const(numx_real_t x) { (void)x; return (numx_real_t)1.0; }
+static numx_real_t f_linear(numx_real_t x){ return x; }
+
+void test_fwd_quadratic_at_3(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_diff_forward(f_quad, 3.0, H, &r));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_FWD, 6.0, r);
+}
+
+void test_fwd_cubic_at_2(void)
+{
+    numx_real_t r;
+    numx_diff_forward(f_cubic, 2.0, H, &r);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_FWD, 12.0, r);
+}
+
+void test_fwd_constant_is_zero(void)
+{
+    numx_real_t r;
+    numx_diff_forward(f_const, 5.0, H, &r);
+    TEST_ASSERT_DOUBLE_WITHIN(1e-12, 0.0, r);
+}
+
+void test_fwd_linear_is_one(void)
+{
+    numx_real_t r;
+    numx_diff_forward(f_linear, 5.0, H, &r);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_FWD, 1.0, r);
+}
+
+void test_fwd_null(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_diff_forward(NULL, 1.0, H, &r));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_diff_forward(f_quad, 1.0, H, NULL));
+}
+
+void test_fwd_nonpositive_h(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_diff_forward(f_quad, 1.0, 0.0, &r));
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_diff_forward(f_quad, 1.0, -1.0, &r));
+}
+
+void test_central_quadratic_at_3(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_diff_central(f_quad, 3.0, H, &r));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_CTR, 6.0, r);
+}
+
+void test_central_quadratic_at_neg2(void)
+{
+    numx_real_t r;
+    numx_diff_central(f_quad, -2.0, H, &r);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_CTR, -4.0, r);
+}
+
+void test_central_cubic_at_2(void)
+{
+    numx_real_t r;
+    numx_diff_central(f_cubic, 2.0, H, &r);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_CTR, 12.0, r);
+}
+
+void test_central_constant_is_zero(void)
+{
+    numx_real_t r;
+    numx_diff_central(f_const, 5.0, H, &r);
+    TEST_ASSERT_DOUBLE_WITHIN(1e-12, 0.0, r);
+}
+
+void test_central_linear_exact(void)
+{
+    numx_real_t r;
+    numx_diff_central(f_linear, 1.0, H, &r);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_CTR, 1.0, r);
+}
+
+void test_central_null(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_diff_central(NULL, 1.0, H, &r));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_diff_central(f_quad, 1.0, H, NULL));
+}
+
+void test_central_nonpositive_h(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_diff_central(f_quad, 1.0, 0.0, &r));
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_diff_central(f_quad, 1.0, -1e-5, &r));
+}
+
+void test_richardson_quadratic_at_3(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_diff_richardson(f_quad, 3.0, H, &r));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_RICH, 6.0, r);
+}
+
+void test_richardson_cubic_at_2(void)
+{
+    numx_real_t r;
+    numx_diff_richardson(f_cubic, 2.0, H, &r);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_RICH, 12.0, r);
+}
+
+void test_richardson_more_accurate_than_central(void)
+{
+    /* With h=0.1, truncation error dominates: Richardson cancels O(h^2). */
+    numx_real_t rc, rr;
+    numx_real_t h_large = 0.1;
+    numx_diff_central(f_cubic, 2.0, h_large, &rc);
+    numx_diff_richardson(f_cubic, 2.0, h_large, &rr);
+    numx_real_t err_c = rc - 12.0;
+    if (err_c < 0.0) err_c = -err_c;
+    numx_real_t err_r = rr - 12.0;
+    if (err_r < 0.0) err_r = -err_r;
+    TEST_ASSERT_TRUE(err_r < err_c);
+}
+
+void test_richardson_constant_is_zero(void)
+{
+    numx_real_t r;
+    numx_diff_richardson(f_const, 5.0, H, &r);
+    TEST_ASSERT_DOUBLE_WITHIN(1e-12, 0.0, r);
+}
+
+void test_richardson_null(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_diff_richardson(NULL, 1.0, H, &r));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_diff_richardson(f_quad, 1.0, H, NULL));
+}
+
+void test_richardson_nonpositive_h(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_diff_richardson(f_quad, 1.0, 0.0, &r));
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_diff_richardson(f_quad, 1.0, -1e-5, &r));
+}
+
+void numx_test_differentiate(void)
+{
+    RUN_TEST(test_fwd_quadratic_at_3);
+    RUN_TEST(test_fwd_cubic_at_2);
+    RUN_TEST(test_fwd_constant_is_zero);
+    RUN_TEST(test_fwd_linear_is_one);
+    RUN_TEST(test_fwd_null);
+    RUN_TEST(test_fwd_nonpositive_h);
+    RUN_TEST(test_central_quadratic_at_3);
+    RUN_TEST(test_central_quadratic_at_neg2);
+    RUN_TEST(test_central_cubic_at_2);
+    RUN_TEST(test_central_constant_is_zero);
+    RUN_TEST(test_central_linear_exact);
+    RUN_TEST(test_central_null);
+    RUN_TEST(test_central_nonpositive_h);
+    RUN_TEST(test_richardson_quadratic_at_3);
+    RUN_TEST(test_richardson_cubic_at_2);
+    RUN_TEST(test_richardson_more_accurate_than_central);
+    RUN_TEST(test_richardson_constant_is_zero);
+    RUN_TEST(test_richardson_null);
+    RUN_TEST(test_richardson_nonpositive_h);
+}

--- a/tests/x64/test_fft.c
+++ b/tests/x64/test_fft.c
@@ -1,0 +1,185 @@
+/**
+ * @file test_fft.c
+ * @brief FFT tests — float64 / x64 host build.
+ *        numx_real_t = double  (compiled with -DNUMX_USE_DOUBLE)
+ *
+ * Twiddle tolerance is relaxed to 1e-6: priv_cos/sin uses a Taylor
+ * approximation whose accuracy improves with double precision but is
+ * still finite-order.
+ * Q15 tests are unchanged (fixed-point, independent of NUMX_USE_DOUBLE).
+ */
+
+#include "unity.h"
+#include "numx/fft.h"
+
+#define TOL       1e-6
+#define TOL_TIGHT 1e-9
+
+void test_fft_dc_n4(void)
+{
+    numx_real_t x[] = {1.0,0.0, 1.0,0.0, 1.0,0.0, 1.0,0.0};
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_fft_f32(x, 4));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 4.0, x[0]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 0.0, x[1]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 0.0, x[2]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 0.0, x[4]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 0.0, x[6]);
+}
+
+void test_fft_single_tone_n4(void)
+{
+    numx_real_t x[] = {1.0,0.0, 0.0,1.0, -1.0,0.0, 0.0,-1.0};
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_fft_f32(x, 4));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 0.0, x[0]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 4.0, x[2]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 0.0, x[3]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 0.0, x[4]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 0.0, x[6]);
+}
+
+void test_fft_dc_n2(void)
+{
+    numx_real_t x[] = {1.0,0.0, 1.0,0.0};
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_fft_f32(x, 2));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 2.0, x[0]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 0.0, x[1]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 0.0, x[2]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 0.0, x[3]);
+}
+
+void test_fft_n1_passthrough(void)
+{
+    numx_real_t x[] = {3.5, -1.2};
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_fft_f32(x, 1));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT,  3.5, x[0]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, -1.2, x[1]);
+}
+
+void test_fft_delta_at_0(void)
+{
+    numx_real_t x[] = {4.0,0.0, 0.0,0.0, 0.0,0.0, 0.0,0.0};
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_fft_f32(x, 4));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 4.0, x[0]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 4.0, x[2]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 4.0, x[4]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 4.0, x[6]);
+}
+
+void test_fft_null_returns_error(void)
+{
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_fft_f32(NULL, 4));
+}
+
+void test_fft_n_not_power_of_two(void)
+{
+    numx_real_t x[6] = {0};
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_fft_f32(x, 3));
+}
+
+void test_fft_n_exceeds_max(void)
+{
+    numx_real_t x[2] = {0};
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_fft_f32(x, NUMX_MAX_FFT_SIZE*2));
+}
+
+void test_ifft_roundtrip(void)
+{
+    numx_real_t orig[] = {1.0,0.0, 2.0,0.0, 3.0,0.0, 0.0,0.0};
+    numx_real_t x[]    = {1.0,0.0, 2.0,0.0, 3.0,0.0, 0.0,0.0};
+    numx_size_t i;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_fft_f32(x, 4));
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_ifft_f32(x, 4));
+    for (i = 0; i < 8; i++) TEST_ASSERT_DOUBLE_WITHIN(TOL, orig[i], x[i]);
+}
+
+void test_ifft_dc_spectrum(void)
+{
+    numx_real_t x[] = {4.0,0.0, 0.0,0.0, 0.0,0.0, 0.0,0.0};
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_ifft_f32(x, 4));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 1.0, x[0]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 0.0, x[1]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 1.0, x[2]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 1.0, x[4]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 1.0, x[6]);
+}
+
+void test_ifft_null_returns_error(void)
+{
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_ifft_f32(NULL, 4));
+}
+
+/* Q15 tests are fixed-point — unchanged between float32 and float64 builds */
+void test_fft_q15_dc_n4(void)
+{
+    numx_q15_t x[] = {0x4000,0, 0x4000,0, 0x4000,0, 0x4000,0};
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_fft_q15(x, 4));
+    TEST_ASSERT_INT16_WITHIN(2, 0x4000, x[0]);
+    TEST_ASSERT_INT16_WITHIN(2, 0,      x[1]);
+    TEST_ASSERT_INT16_WITHIN(2, 0, x[2]);
+    TEST_ASSERT_INT16_WITHIN(2, 0, x[4]);
+    TEST_ASSERT_INT16_WITHIN(2, 0, x[6]);
+}
+
+void test_fft_q15_null_returns_error(void)
+{
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_fft_q15(NULL, 4));
+}
+
+void test_fft_q15_n_not_power_of_two(void)
+{
+    numx_q15_t x[6] = {0};
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_fft_q15(x, 3));
+}
+
+void test_fft_magnitude_dc(void)
+{
+    numx_real_t fft_out[] = {4.0,0.0, 0.0,0.0, 0.0,0.0, 0.0,0.0};
+    numx_real_t mag[3];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_fft_magnitude(fft_out, 4, mag));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 4.0, mag[0]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 0.0, mag[1]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TIGHT, 0.0, mag[2]);
+}
+
+void test_fft_magnitude_complex_bin(void)
+{
+    numx_real_t fft_out[] = {3.0,4.0, 0.0,0.0, 0.0,0.0};
+    numx_real_t mag[2];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_fft_magnitude(fft_out, 2, mag));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 5.0, mag[0]);
+}
+
+void test_fft_magnitude_null_returns_error(void)
+{
+    numx_real_t fft_out[4]={0}, mag[3]={0};
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_fft_magnitude(NULL, 4, mag));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_fft_magnitude(fft_out, 4, NULL));
+}
+
+void test_fft_magnitude_n1_invalid(void)
+{
+    numx_real_t fft_out[2]={0}, mag[1]={0};
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_fft_magnitude(fft_out, 1, mag));
+}
+
+void numx_test_fft(void)
+{
+    RUN_TEST(test_fft_dc_n4);
+    RUN_TEST(test_fft_single_tone_n4);
+    RUN_TEST(test_fft_dc_n2);
+    RUN_TEST(test_fft_n1_passthrough);
+    RUN_TEST(test_fft_delta_at_0);
+    RUN_TEST(test_fft_null_returns_error);
+    RUN_TEST(test_fft_n_not_power_of_two);
+    RUN_TEST(test_fft_n_exceeds_max);
+    RUN_TEST(test_ifft_roundtrip);
+    RUN_TEST(test_ifft_dc_spectrum);
+    RUN_TEST(test_ifft_null_returns_error);
+    RUN_TEST(test_fft_q15_dc_n4);
+    RUN_TEST(test_fft_q15_null_returns_error);
+    RUN_TEST(test_fft_q15_n_not_power_of_two);
+    RUN_TEST(test_fft_magnitude_dc);
+    RUN_TEST(test_fft_magnitude_complex_bin);
+    RUN_TEST(test_fft_magnitude_null_returns_error);
+    RUN_TEST(test_fft_magnitude_n1_invalid);
+}

--- a/tests/x64/test_integrate.c
+++ b/tests/x64/test_integrate.c
@@ -1,0 +1,218 @@
+/**
+ * @file test_integrate.c
+ * @brief Integration tests — float64 / x64 host build.
+ *        numx_real_t = double  (compiled with -DNUMX_USE_DOUBLE)
+ *
+ * TOL_TRAP: trapezoid is O(h^2); n=1000 gives ~1e-6 truncation.
+ * TOL_SIMP: Simpson exact for cubics — near machine epsilon.
+ * TOL_GAUSS: Gauss nodes/weights stored as float32 literals in the library;
+ *            promoted to double they carry ~1e-7 weight error. Use 1e-6.
+ */
+
+#include "unity.h"
+#include "numx/numx_types.h"
+#include "numx/integrate.h"
+
+#define TOL_TRAP  1e-5
+#define TOL_SIMP  1e-10
+#define TOL_GAUSS 1e-6
+
+static numx_real_t f_one(numx_real_t x)   { (void)x; return (numx_real_t)1.0; }
+static numx_real_t f_linear(numx_real_t x){ return x; }
+static numx_real_t f_quad(numx_real_t x)  { return x*x; }
+static numx_real_t f_cubic(numx_real_t x) { return x*x*x; }
+static numx_real_t f_neg(numx_real_t x)   { return -x; }
+
+void test_trap_constant_one(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_integrate_trap(f_one, 0.0, 1.0, 100, &r));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TRAP, 1.0, r);
+}
+
+void test_trap_linear(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_integrate_trap(f_linear, 0.0, 1.0, 100, &r));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TRAP, 0.5, r);
+}
+
+void test_trap_quadratic(void)
+{
+    numx_real_t r;
+    numx_integrate_trap(f_quad, 0.0, 1.0, 1000, &r);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TRAP, 1.0/3.0, r);
+}
+
+void test_trap_linearity(void)
+{
+    numx_real_t r1, r2;
+    numx_integrate_trap(f_linear, 0.0, 2.0, 100, &r1);
+    numx_integrate_trap(f_neg, 0.0, 2.0, 100, &r2);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TRAP, r1, -r2);
+}
+
+void test_trap_n1(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_integrate_trap(f_one, 0.0, 1.0, 1, &r));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_TRAP, 1.0, r);
+}
+
+void test_trap_null(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_integrate_trap(NULL, 0.0, 1.0, 10, &r));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_integrate_trap(f_one, 0.0, 1.0, 10, NULL));
+}
+
+void test_trap_a_ge_b(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_integrate_trap(f_one, 1.0, 0.0, 10, &r));
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_integrate_trap(f_one, 1.0, 1.0, 10, &r));
+}
+
+void test_trap_n_zero(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_integrate_trap(f_one, 0.0, 1.0, 0, &r));
+}
+
+void test_simpson_constant_one(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_integrate_simpson(f_one, 0.0, 1.0, 2, &r));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_SIMP, 1.0, r);
+}
+
+void test_simpson_linear_exact(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_integrate_simpson(f_linear, 0.0, 1.0, 2, &r));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_SIMP, 0.5, r);
+}
+
+void test_simpson_quadratic_exact(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_integrate_simpson(f_quad, 0.0, 1.0, 4, &r));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_SIMP, 1.0/3.0, r);
+}
+
+void test_simpson_cubic_exact(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_integrate_simpson(f_cubic, 0.0, 1.0, 4, &r));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_SIMP, 0.25, r);
+}
+
+void test_simpson_wider_interval(void)
+{
+    numx_real_t r;
+    numx_integrate_simpson(f_quad, 0.0, 3.0, 6, &r);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_SIMP, 9.0, r);
+}
+
+void test_simpson_odd_n_rejected(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_integrate_simpson(f_one, 0.0, 1.0, 3, &r));
+}
+
+void test_simpson_n_lt_2_rejected(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_integrate_simpson(f_one, 0.0, 1.0, 0, &r));
+}
+
+void test_simpson_null(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_integrate_simpson(NULL, 0.0, 1.0, 4, &r));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_integrate_simpson(f_one, 0.0, 1.0, 4, NULL));
+}
+
+void test_gauss2_linear(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_integrate_gauss(f_linear, 0.0, 1.0, 2, &r));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_GAUSS, 0.5, r);
+}
+
+void test_gauss4_quadratic_exact(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_integrate_gauss(f_quad, 0.0, 1.0, 4, &r));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_GAUSS, 1.0/3.0, r);
+}
+
+void test_gauss8_cubic_exact(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_integrate_gauss(f_cubic, 0.0, 1.0, 8, &r));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_GAUSS, 0.25, r);
+}
+
+void test_gauss8_constant_exact(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_integrate_gauss(f_one, -3.0, 3.0, 8, &r));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_GAUSS, 6.0, r);
+}
+
+void test_gauss_null(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_integrate_gauss(NULL, 0.0, 1.0, 4, &r));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_integrate_gauss(f_one, 0.0, 1.0, 4, NULL));
+}
+
+void test_gauss_invalid_npts(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_integrate_gauss(f_one, 0.0, 1.0, 3, &r));
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_integrate_gauss(f_one, 0.0, 1.0, 16, &r));
+}
+
+void test_gauss_a_ge_b(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_integrate_gauss(f_one, 1.0, 0.0, 4, &r));
+}
+
+void numx_test_integrate(void)
+{
+    RUN_TEST(test_trap_constant_one);
+    RUN_TEST(test_trap_linear);
+    RUN_TEST(test_trap_quadratic);
+    RUN_TEST(test_trap_linearity);
+    RUN_TEST(test_trap_n1);
+    RUN_TEST(test_trap_null);
+    RUN_TEST(test_trap_a_ge_b);
+    RUN_TEST(test_trap_n_zero);
+    RUN_TEST(test_simpson_constant_one);
+    RUN_TEST(test_simpson_linear_exact);
+    RUN_TEST(test_simpson_quadratic_exact);
+    RUN_TEST(test_simpson_cubic_exact);
+    RUN_TEST(test_simpson_wider_interval);
+    RUN_TEST(test_simpson_odd_n_rejected);
+    RUN_TEST(test_simpson_n_lt_2_rejected);
+    RUN_TEST(test_simpson_null);
+    RUN_TEST(test_gauss2_linear);
+    RUN_TEST(test_gauss4_quadratic_exact);
+    RUN_TEST(test_gauss8_cubic_exact);
+    RUN_TEST(test_gauss8_constant_exact);
+    RUN_TEST(test_gauss_null);
+    RUN_TEST(test_gauss_invalid_npts);
+    RUN_TEST(test_gauss_a_ge_b);
+}

--- a/tests/x64/test_interpolate.c
+++ b/tests/x64/test_interpolate.c
@@ -1,0 +1,245 @@
+/**
+ * @file test_interpolate.c
+ * @brief Interpolation tests — float64 / x64 host build.
+ *        numx_real_t = double  (compiled with -DNUMX_USE_DOUBLE)
+ */
+
+#include "unity.h"
+#include "numx/numx_types.h"
+#include "numx/interpolate.h"
+
+#define TOL      1e-8
+#define TOL_CHEB 1e-8
+
+static numx_real_t f_quad(numx_real_t x)  { return x*x; }
+static numx_real_t f_linear(numx_real_t x){ return x; }
+static numx_real_t f_const(numx_real_t x) { (void)x; return (numx_real_t)3.0; }
+
+void test_linear_midpoint_known(void)
+{
+    numx_real_t xs[] = {0.0,1.0,2.0};
+    numx_real_t ys[] = {0.0,1.0,4.0};
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_interp_linear(xs, ys, 3, 0.5, &r));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 0.5, r);
+}
+
+void test_linear_second_interval(void)
+{
+    numx_real_t xs[] = {0.0,1.0,2.0};
+    numx_real_t ys[] = {0.0,1.0,4.0};
+    numx_real_t r;
+    numx_interp_linear(xs, ys, 3, 1.5, &r);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 2.5, r);
+}
+
+void test_linear_at_knots(void)
+{
+    numx_real_t xs[] = {0.0,1.0,3.0,6.0};
+    numx_real_t ys[] = {1.0,3.0,2.0,5.0};
+    numx_real_t r; numx_size_t i;
+    for (i = 0; i < 4; i++)
+    {
+        numx_interp_linear(xs, ys, 4, xs[i], &r);
+        TEST_ASSERT_DOUBLE_WITHIN(TOL, ys[i], r);
+    }
+}
+
+void test_linear_clamp_below(void)
+{
+    numx_real_t xs[] = {1.0,2.0,3.0};
+    numx_real_t ys[] = {10.0,20.0,30.0};
+    numx_real_t r;
+    numx_interp_linear(xs, ys, 3, 0.0, &r);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 10.0, r);
+}
+
+void test_linear_clamp_above(void)
+{
+    numx_real_t xs[] = {1.0,2.0,3.0};
+    numx_real_t ys[] = {10.0,20.0,30.0};
+    numx_real_t r;
+    numx_interp_linear(xs, ys, 3, 5.0, &r);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 30.0, r);
+}
+
+void test_linear_n2(void)
+{
+    numx_real_t xs[] = {0.0,4.0}, ys[] = {0.0,8.0}, r;
+    numx_interp_linear(xs, ys, 2, 2.0, &r);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 4.0, r);
+}
+
+void test_linear_null(void)
+{
+    numx_real_t xs[] = {0.0,1.0}, ys[] = {0.0,1.0}, r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_interp_linear(NULL, ys, 2, 0.5, &r));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_interp_linear(xs, NULL, 2, 0.5, &r));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_interp_linear(xs, ys, 2, 0.5, NULL));
+}
+
+void test_linear_n_lt_2(void)
+{
+    numx_real_t xs[] = {1.0}, ys[] = {1.0}, r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_interp_linear(xs, ys, 1, 1.0, &r));
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_interp_linear(xs, ys, 0, 1.0, &r));
+}
+
+void test_spline_linear_data_exact(void)
+{
+    numx_real_t xs[] = {0.0,1.0,2.0,3.0};
+    numx_real_t ys[] = {0.0,1.0,2.0,3.0};
+    numx_real_t m[4], r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_interp_spline_precompute(xs, ys, 4, m));
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_interp_spline_eval(xs, ys, m, 4, 0.5, &r));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 0.5, r);
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_interp_spline_eval(xs, ys, m, 4, 1.7, &r));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 1.7, r);
+}
+
+void test_spline_cubic_oneshot_midpoint(void)
+{
+    numx_real_t xs[] = {0.0,1.0,2.0,3.0};
+    numx_real_t ys[] = {0.0,1.0,4.0,9.0};
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_interp_spline_cubic(xs, ys, 4, 0.5, &r));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 0.35, r);
+}
+
+void test_spline_at_knots(void)
+{
+    numx_real_t xs[] = {0.0,1.0,2.0,3.0,4.0};
+    numx_real_t ys[] = {1.0,3.0,2.0,5.0,4.0};
+    numx_real_t m[5], r; numx_size_t i;
+    numx_interp_spline_precompute(xs, ys, 5, m);
+    for (i = 0; i < 5; i++)
+    {
+        numx_interp_spline_eval(xs, ys, m, 5, xs[i], &r);
+        TEST_ASSERT_DOUBLE_WITHIN(TOL, ys[i], r);
+    }
+}
+
+void test_spline_clamp_below(void)
+{
+    numx_real_t xs[] = {1.0,2.0,3.0}, ys[] = {1.0,4.0,9.0}, r;
+    numx_interp_spline_cubic(xs, ys, 3, 0.0, &r);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 1.0, r);
+}
+
+void test_spline_clamp_above(void)
+{
+    numx_real_t xs[] = {1.0,2.0,3.0}, ys[] = {1.0,4.0,9.0}, r;
+    numx_interp_spline_cubic(xs, ys, 3, 5.0, &r);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 9.0, r);
+}
+
+void test_spline_n2(void)
+{
+    numx_real_t xs[] = {0.0,2.0}, ys[] = {0.0,4.0}, r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_interp_spline_cubic(xs, ys, 2, 1.0, &r));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 2.0, r);
+}
+
+void test_spline_precompute_null(void)
+{
+    numx_real_t xs[] = {0.0,1.0}, ys[] = {0.0,1.0}, m[2];
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_interp_spline_precompute(NULL, ys, 2, m));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_interp_spline_precompute(xs, NULL, 2, m));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_interp_spline_precompute(xs, ys, 2, NULL));
+}
+
+void test_spline_precompute_n_lt_2(void)
+{
+    numx_real_t xs[] = {1.0}, ys[] = {1.0}, m[1];
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_interp_spline_precompute(xs, ys, 1, m));
+}
+
+void test_cheb_constant(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_interp_chebyshev(f_const, 4, 0.0, 1.0, 0.5, &r));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_CHEB, 3.0, r);
+}
+
+void test_cheb_linear_exact(void)
+{
+    numx_real_t r;
+    numx_interp_chebyshev(f_linear, 4, 0.0, 2.0, 1.0, &r);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_CHEB, 1.0, r);
+}
+
+void test_cheb_quadratic_exact(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_interp_chebyshev(f_quad, 4, -1.0, 1.0, 0.5, &r));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_CHEB, 0.25, r);
+}
+
+void test_cheb_quadratic_at_zero(void)
+{
+    numx_real_t r;
+    numx_interp_chebyshev(f_quad, 4, -1.0, 1.0, 0.0, &r);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_CHEB, 0.0, r);
+}
+
+void test_cheb_n2_gives_linear_interp(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_interp_chebyshev(f_quad, 2, -1.0, 1.0, 0.0, &r));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_CHEB, 0.5, r);
+}
+
+void test_cheb_null(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_interp_chebyshev(NULL, 4, 0.0, 1.0, 0.5, &r));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_interp_chebyshev(f_quad, 4, 0.0, 1.0, 0.5, NULL));
+}
+
+void test_cheb_b_le_a(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_interp_chebyshev(f_quad, 4, 1.0, 0.0, 0.5, &r));
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_interp_chebyshev(f_quad, 4, 1.0, 1.0, 0.5, &r));
+}
+
+void test_cheb_n_lt_2(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_interp_chebyshev(f_quad, 1, 0.0, 1.0, 0.5, &r));
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_interp_chebyshev(f_quad, 0, 0.0, 1.0, 0.5, &r));
+}
+
+void numx_test_interpolate(void)
+{
+    RUN_TEST(test_linear_midpoint_known);
+    RUN_TEST(test_linear_second_interval);
+    RUN_TEST(test_linear_at_knots);
+    RUN_TEST(test_linear_clamp_below);
+    RUN_TEST(test_linear_clamp_above);
+    RUN_TEST(test_linear_n2);
+    RUN_TEST(test_linear_null);
+    RUN_TEST(test_linear_n_lt_2);
+    RUN_TEST(test_spline_linear_data_exact);
+    RUN_TEST(test_spline_cubic_oneshot_midpoint);
+    RUN_TEST(test_spline_at_knots);
+    RUN_TEST(test_spline_clamp_below);
+    RUN_TEST(test_spline_clamp_above);
+    RUN_TEST(test_spline_n2);
+    RUN_TEST(test_spline_precompute_null);
+    RUN_TEST(test_spline_precompute_n_lt_2);
+    RUN_TEST(test_cheb_constant);
+    RUN_TEST(test_cheb_linear_exact);
+    RUN_TEST(test_cheb_quadratic_exact);
+    RUN_TEST(test_cheb_quadratic_at_zero);
+    RUN_TEST(test_cheb_n2_gives_linear_interp);
+    RUN_TEST(test_cheb_null);
+    RUN_TEST(test_cheb_b_le_a);
+    RUN_TEST(test_cheb_n_lt_2);
+}

--- a/tests/x64/test_linalg.c
+++ b/tests/x64/test_linalg.c
@@ -1,0 +1,498 @@
+/**
+ * @file test_linalg.c
+ * @brief Linear algebra tests — float64 / x64 host build.
+ *        numx_real_t = double  (compiled with -DNUMX_USE_DOUBLE)
+ *
+ * L1 Known-answer | L2 Property | L3 Edge case | L4 Error handling
+ */
+
+#include "unity.h"
+#include "numx/numx_types.h"
+#include "numx/linalg.h"
+
+#define TOL    1e-10
+#define TOL_LU 1e-9
+
+/* ── numx_vec_dot ──────────────────────────────────────────────────── */
+
+void test_vec_dot_known(void)
+{
+    numx_real_t a[] = {1.0, 2.0, 3.0};
+    numx_real_t b[] = {4.0, 5.0, 6.0};
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_vec_dot(a, b, 3, &r));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 32.0, r);
+}
+
+void test_vec_dot_orthogonal(void)
+{
+    numx_real_t a[] = {1.0, 0.0, 0.0};
+    numx_real_t b[] = {0.0, 1.0, 0.0};
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_vec_dot(a, b, 3, &r));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 0.0, r);
+}
+
+void test_vec_dot_commutative(void)
+{
+    numx_real_t a[] = {1.0, 2.0, 3.0};
+    numx_real_t b[] = {4.0, 5.0, 6.0};
+    numx_real_t r1, r2;
+    numx_vec_dot(a, b, 3, &r1);
+    numx_vec_dot(b, a, 3, &r2);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, r1, r2);
+}
+
+void test_vec_dot_self_equals_sq_norm(void)
+{
+    numx_real_t a[] = {3.0, 4.0};
+    numx_real_t r;
+    numx_vec_dot(a, a, 2, &r);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 25.0, r);
+}
+
+void test_vec_dot_single_element(void)
+{
+    numx_real_t a[] = {7.0};
+    numx_real_t b[] = {3.0};
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_vec_dot(a, b, 1, &r));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 21.0, r);
+}
+
+void test_vec_dot_zero_vector(void)
+{
+    numx_real_t a[] = {0.0, 0.0, 0.0};
+    numx_real_t b[] = {1.0, 2.0, 3.0};
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_vec_dot(a, b, 3, &r));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 0.0, r);
+}
+
+void test_vec_dot_null_a(void)
+{
+    numx_real_t b[] = {1.0}, r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_vec_dot(NULL, b, 1, &r));
+}
+
+void test_vec_dot_null_b(void)
+{
+    numx_real_t a[] = {1.0}, r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_vec_dot(a, NULL, 1, &r));
+}
+
+void test_vec_dot_null_result(void)
+{
+    numx_real_t a[] = {1.0}, b[] = {1.0};
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_vec_dot(a, b, 1, NULL));
+}
+
+void test_vec_dot_zero_n(void)
+{
+    numx_real_t a[] = {1.0}, b[] = {1.0}, r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_vec_dot(a, b, 0, &r));
+}
+
+/* ── numx_vec_norm ─────────────────────────────────────────────────── */
+
+void test_vec_norm_l2_pythagorean(void)
+{
+    numx_real_t a[] = {3.0, 4.0};
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_vec_norm(a, 2, NUMX_NORM_L2, &r));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 5.0, r);
+}
+
+void test_vec_norm_l1_known(void)
+{
+    numx_real_t a[] = {3.0, -4.0, 0.0};
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_vec_norm(a, 3, NUMX_NORM_L1, &r));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 7.0, r);
+}
+
+void test_vec_norm_linf_known(void)
+{
+    numx_real_t a[] = {3.0, -5.0, 4.0};
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_vec_norm(a, 3, NUMX_NORM_INF, &r));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 5.0, r);
+}
+
+void test_vec_norm_unit_vector_is_one(void)
+{
+    numx_real_t a[] = {1.0, 0.0, 0.0};
+    numx_real_t r;
+    numx_vec_norm(a, 3, NUMX_NORM_L2, &r);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 1.0, r);
+}
+
+void test_vec_norm_zero_vector_is_zero(void)
+{
+    numx_real_t a[] = {0.0, 0.0, 0.0};
+    numx_real_t r;
+    numx_vec_norm(a, 3, NUMX_NORM_L2, &r);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 0.0, r);
+}
+
+void test_vec_norm_null_a(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_vec_norm(NULL, 3, NUMX_NORM_L2, &r));
+}
+
+void test_vec_norm_null_result(void)
+{
+    numx_real_t a[] = {1.0, 2.0};
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_vec_norm(a, 2, NUMX_NORM_L2, NULL));
+}
+
+void test_vec_norm_unknown_type(void)
+{
+    numx_real_t a[] = {1.0}, r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_vec_norm(a, 1, (numx_norm_t)99, &r));
+}
+
+/* ── numx_vec_cross3 ───────────────────────────────────────────────── */
+
+void test_vec_cross3_x_cross_y(void)
+{
+    numx_real_t a[] = {1.0, 0.0, 0.0};
+    numx_real_t b[] = {0.0, 1.0, 0.0};
+    numx_real_t r[3];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_vec_cross3(a, b, r));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 0.0, r[0]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 0.0, r[1]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 1.0, r[2]);
+}
+
+void test_vec_cross3_anticommutative(void)
+{
+    numx_real_t a[] = {1.0, 2.0, 3.0};
+    numx_real_t b[] = {4.0, 5.0, 6.0};
+    numx_real_t axb[3], bxa[3];
+    numx_vec_cross3(a, b, axb);
+    numx_vec_cross3(b, a, bxa);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, -axb[0], bxa[0]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, -axb[1], bxa[1]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, -axb[2], bxa[2]);
+}
+
+void test_vec_cross3_parallel_is_zero(void)
+{
+    numx_real_t a[] = {2.0, 0.0, 0.0};
+    numx_real_t b[] = {5.0, 0.0, 0.0};
+    numx_real_t r[3];
+    numx_vec_cross3(a, b, r);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 0.0, r[0]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 0.0, r[1]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 0.0, r[2]);
+}
+
+void test_vec_cross3_alias_safe(void)
+{
+    numx_real_t a[] = {1.0, 0.0, 0.0};
+    numx_real_t b[] = {0.0, 1.0, 0.0};
+    numx_vec_cross3(a, b, a);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 0.0, a[0]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 0.0, a[1]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 1.0, a[2]);
+}
+
+void test_vec_cross3_null(void)
+{
+    numx_real_t b[] = {1.0, 0.0, 0.0}, r[3];
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_vec_cross3(NULL, b, r));
+}
+
+/* ── numx_mat_mul ──────────────────────────────────────────────────── */
+
+void test_mat_mul_2x2(void)
+{
+    numx_real_t A[] = {1.0, 2.0, 3.0, 4.0};
+    numx_real_t B[] = {5.0, 6.0, 7.0, 8.0};
+    numx_real_t C[4];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_mat_mul(A, 2, 2, B, 2, 2, C));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 19.0, C[0]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 22.0, C[1]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 43.0, C[2]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 50.0, C[3]);
+}
+
+void test_mat_mul_2x3_times_3x2(void)
+{
+    numx_real_t A[] = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
+    numx_real_t B[] = {7.0, 8.0, 9.0, 10.0, 11.0, 12.0};
+    numx_real_t C[4];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_mat_mul(A, 2, 3, B, 3, 2, C));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL,  58.0, C[0]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL,  64.0, C[1]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 139.0, C[2]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 154.0, C[3]);
+}
+
+void test_mat_mul_identity(void)
+{
+    numx_real_t A[] = {1.0, 2.0, 3.0, 4.0};
+    numx_real_t I[] = {1.0, 0.0, 0.0, 1.0};
+    numx_real_t C[4];
+    numx_mat_mul(A, 2, 2, I, 2, 2, C);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, A[0], C[0]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, A[1], C[1]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, A[2], C[2]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, A[3], C[3]);
+}
+
+void test_mat_mul_dim_mismatch(void)
+{
+    numx_real_t A[6] = {0}, B[4] = {0}, C[4] = {0};
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_mat_mul(A, 2, 3, B, 2, 2, C));
+}
+
+void test_mat_mul_null_A(void)
+{
+    numx_real_t B[4] = {0}, C[4] = {0};
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_mat_mul(NULL, 2, 2, B, 2, 2, C));
+}
+
+/* ── numx_mat_transpose ────────────────────────────────────────────── */
+
+void test_mat_transpose_2x3(void)
+{
+    numx_real_t A[] = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
+    numx_real_t AT[6];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_mat_transpose(A, 2, 3, AT));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 1.0, AT[0]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 4.0, AT[1]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 2.0, AT[2]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 5.0, AT[3]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 3.0, AT[4]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 6.0, AT[5]);
+}
+
+void test_mat_transpose_double_is_identity(void)
+{
+    numx_real_t A[] = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
+    numx_real_t AT[6], ATT[6];
+    numx_size_t i;
+    numx_mat_transpose(A, 2, 3, AT);
+    numx_mat_transpose(AT, 3, 2, ATT);
+    for (i = 0; i < 6; i++)
+        TEST_ASSERT_DOUBLE_WITHIN(TOL, A[i], ATT[i]);
+}
+
+void test_mat_transpose_sq_inplace(void)
+{
+    numx_real_t A[] = {1.0, 2.0, 3.0, 4.0};
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_mat_transpose_sq(A, 2));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 1.0, A[0]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 3.0, A[1]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 2.0, A[2]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 4.0, A[3]);
+}
+
+void test_mat_transpose_sq_twice_is_identity(void)
+{
+    numx_real_t A[] = {1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,9.0};
+    numx_real_t orig[9];
+    numx_size_t i;
+    for (i = 0; i < 9; i++) orig[i] = A[i];
+    numx_mat_transpose_sq(A, 3);
+    numx_mat_transpose_sq(A, 3);
+    for (i = 0; i < 9; i++)
+        TEST_ASSERT_DOUBLE_WITHIN(TOL, orig[i], A[i]);
+}
+
+void test_mat_transpose_null(void)
+{
+    numx_real_t AT[4];
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_mat_transpose(NULL, 2, 2, AT));
+}
+
+void test_mat_transpose_sq_null(void)
+{
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_mat_transpose_sq(NULL, 2));
+}
+
+/* ── numx_mat_det ──────────────────────────────────────────────────── */
+
+void test_mat_det_1x1(void)
+{
+    numx_real_t A[] = {7.0};
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_mat_det(A, 1, &r));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 7.0, r);
+}
+
+void test_mat_det_2x2(void)
+{
+    numx_real_t A[] = {1.0, 2.0, 3.0, 4.0};
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_mat_det(A, 2, &r));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, -2.0, r);
+}
+
+void test_mat_det_3x3(void)
+{
+    numx_real_t A[] = {1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,10.0};
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_mat_det(A, 3, &r));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, -3.0, r);
+}
+
+void test_mat_det_identity_is_one(void)
+{
+    numx_real_t I[] = {1.0,0.0,0.0,0.0,1.0,0.0,0.0,0.0,1.0};
+    numx_real_t r;
+    numx_mat_det(I, 3, &r);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 1.0, r);
+}
+
+void test_mat_det_singular_is_zero(void)
+{
+    numx_real_t A[] = {1.0, 2.0, 2.0, 4.0};
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_mat_det(A, 2, &r));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 0.0, r);
+}
+
+void test_mat_det_null(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_mat_det(NULL, 2, &r));
+}
+
+void test_mat_det_null_result(void)
+{
+    numx_real_t A[] = {1.0, 0.0, 0.0, 1.0};
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_mat_det(A, 2, NULL));
+}
+
+/* ── numx_lu_decompose / numx_lu_solve ────────────────────────────── */
+
+void test_lu_solve_3x3_textbook(void)
+{
+    numx_real_t A[] = { 2.0, 1.0,-1.0,
+                       -3.0,-1.0, 2.0,
+                       -2.0, 1.0, 2.0};
+    numx_real_t b[] = {8.0,-11.0,-3.0};
+    numx_real_t LU[9]; numx_idx_t pivot[3]; numx_real_t x[3];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_lu_decompose(A, 3, LU, pivot));
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_lu_solve(LU, pivot, 3, b, x));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_LU,  2.0, x[0]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_LU,  3.0, x[1]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_LU, -1.0, x[2]);
+}
+
+void test_lu_solve_identity_system(void)
+{
+    numx_real_t A[] = {1.0,0.0,0.0,1.0};
+    numx_real_t b[] = {5.0,7.0};
+    numx_real_t LU[4]; numx_idx_t pivot[2]; numx_real_t x[2];
+    numx_lu_decompose(A, 2, LU, pivot);
+    numx_lu_solve(LU, pivot, 2, b, x);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 5.0, x[0]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 7.0, x[1]);
+}
+
+void test_lu_solve_residual_is_zero(void)
+{
+    numx_real_t A[] = { 2.0, 1.0,-1.0,
+                       -3.0,-1.0, 2.0,
+                       -2.0, 1.0, 2.0};
+    numx_real_t b[] = {8.0,-11.0,-3.0};
+    numx_real_t LU[9]; numx_idx_t pivot[3];
+    numx_real_t x[3], Ax[3];
+    numx_lu_decompose(A, 3, LU, pivot);
+    numx_lu_solve(LU, pivot, 3, b, x);
+    numx_mat_mul(A, 3, 3, x, 3, 1, Ax);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_LU, b[0], Ax[0]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_LU, b[1], Ax[1]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_LU, b[2], Ax[2]);
+}
+
+void test_lu_decompose_singular(void)
+{
+    numx_real_t A[] = {1.0,2.0,2.0,4.0};
+    numx_real_t LU[4]; numx_idx_t pivot[2];
+    TEST_ASSERT_EQUAL(NUMX_ERR_SINGULAR, numx_lu_decompose(A, 2, LU, pivot));
+}
+
+void test_lu_decompose_null_A(void)
+{
+    numx_real_t LU[4]; numx_idx_t pivot[2];
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_lu_decompose(NULL, 2, LU, pivot));
+}
+
+void test_lu_decompose_null_LU(void)
+{
+    numx_real_t A[4] = {0}; numx_idx_t pivot[2] = {0};
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_lu_decompose(A, 2, NULL, pivot));
+}
+
+void test_lu_solve_null_LU(void)
+{
+    numx_real_t b[2] = {0}, x[2] = {0}; numx_idx_t pivot[2] = {0,1};
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_lu_solve(NULL, pivot, 2, b, x));
+}
+
+void test_lu_solve_null_x(void)
+{
+    numx_real_t LU[4] = {1,0,0,1}, b[2] = {1,1}; numx_idx_t pivot[2] = {0,1};
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_lu_solve(LU, pivot, 2, b, NULL));
+}
+
+/* ── Suite entry point ─────────────────────────────────────────────── */
+
+void numx_test_linalg(void)
+{
+    RUN_TEST(test_vec_dot_known);
+    RUN_TEST(test_vec_dot_orthogonal);
+    RUN_TEST(test_vec_dot_commutative);
+    RUN_TEST(test_vec_dot_self_equals_sq_norm);
+    RUN_TEST(test_vec_dot_single_element);
+    RUN_TEST(test_vec_dot_zero_vector);
+    RUN_TEST(test_vec_dot_null_a);
+    RUN_TEST(test_vec_dot_null_b);
+    RUN_TEST(test_vec_dot_null_result);
+    RUN_TEST(test_vec_dot_zero_n);
+    RUN_TEST(test_vec_norm_l2_pythagorean);
+    RUN_TEST(test_vec_norm_l1_known);
+    RUN_TEST(test_vec_norm_linf_known);
+    RUN_TEST(test_vec_norm_unit_vector_is_one);
+    RUN_TEST(test_vec_norm_zero_vector_is_zero);
+    RUN_TEST(test_vec_norm_null_a);
+    RUN_TEST(test_vec_norm_null_result);
+    RUN_TEST(test_vec_norm_unknown_type);
+    RUN_TEST(test_vec_cross3_x_cross_y);
+    RUN_TEST(test_vec_cross3_anticommutative);
+    RUN_TEST(test_vec_cross3_parallel_is_zero);
+    RUN_TEST(test_vec_cross3_alias_safe);
+    RUN_TEST(test_vec_cross3_null);
+    RUN_TEST(test_mat_mul_2x2);
+    RUN_TEST(test_mat_mul_2x3_times_3x2);
+    RUN_TEST(test_mat_mul_identity);
+    RUN_TEST(test_mat_mul_dim_mismatch);
+    RUN_TEST(test_mat_mul_null_A);
+    RUN_TEST(test_mat_transpose_2x3);
+    RUN_TEST(test_mat_transpose_double_is_identity);
+    RUN_TEST(test_mat_transpose_sq_inplace);
+    RUN_TEST(test_mat_transpose_sq_twice_is_identity);
+    RUN_TEST(test_mat_transpose_null);
+    RUN_TEST(test_mat_transpose_sq_null);
+    RUN_TEST(test_mat_det_1x1);
+    RUN_TEST(test_mat_det_2x2);
+    RUN_TEST(test_mat_det_3x3);
+    RUN_TEST(test_mat_det_identity_is_one);
+    RUN_TEST(test_mat_det_singular_is_zero);
+    RUN_TEST(test_mat_det_null);
+    RUN_TEST(test_mat_det_null_result);
+    RUN_TEST(test_lu_solve_3x3_textbook);
+    RUN_TEST(test_lu_solve_identity_system);
+    RUN_TEST(test_lu_solve_residual_is_zero);
+    RUN_TEST(test_lu_decompose_singular);
+    RUN_TEST(test_lu_decompose_null_A);
+    RUN_TEST(test_lu_decompose_null_LU);
+    RUN_TEST(test_lu_solve_null_LU);
+    RUN_TEST(test_lu_solve_null_x);
+}

--- a/tests/x64/test_ode.c
+++ b/tests/x64/test_ode.c
@@ -1,0 +1,217 @@
+/**
+ * @file test_ode.c
+ * @brief ODE solver tests — float64 / x64 host build.
+ *        numx_real_t = double  (compiled with -DNUMX_USE_DOUBLE)
+ */
+
+#include "unity.h"
+#include "numx/numx_types.h"
+#include "numx/ode.h"
+
+#define TOL_RK4  1e-5
+#define TOL_RK45 1e-5
+#define RK45_TOL 1e-7
+
+static numx_status_t ode_growth(numx_real_t t, const numx_real_t *y,
+                                numx_size_t n, numx_real_t *dydt)
+{
+    numx_size_t i; (void)t;
+    for (i = 0; i < n; i++) dydt[i] = y[i];
+    return NUMX_OK;
+}
+
+static numx_status_t ode_decay(numx_real_t t, const numx_real_t *y,
+                               numx_size_t n, numx_real_t *dydt)
+{
+    numx_size_t i; (void)t;
+    for (i = 0; i < n; i++) dydt[i] = -y[i];
+    return NUMX_OK;
+}
+
+static numx_status_t ode_harmonic(numx_real_t t, const numx_real_t *y,
+                                  numx_size_t n, numx_real_t *dydt)
+{
+    (void)t; (void)n;
+    dydt[0] =  y[1];
+    dydt[1] = -y[0];
+    return NUMX_OK;
+}
+
+static numx_status_t ode_error(numx_real_t t, const numx_real_t *y,
+                               numx_size_t n, numx_real_t *dydt)
+{
+    (void)t; (void)y; (void)n; (void)dydt;
+    return NUMX_ERR_SINGULAR;
+}
+
+void test_rk4_growth_at_t1(void)
+{
+    numx_real_t y[] = {1.0};
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_ode_rk4(ode_growth, 0.0, y, 1, 1e-3, 1000, y));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_RK4, 2.718281828459045, y[0]);
+}
+
+void test_rk4_decay_at_t1(void)
+{
+    numx_real_t y[] = {1.0};
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_ode_rk4(ode_decay, 0.0, y, 1, 1e-3, 1000, y));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_RK4, 0.36787944117144233, y[0]);
+}
+
+void test_rk4_growth_at_t2(void)
+{
+    numx_real_t y[] = {1.0};
+    numx_ode_rk4(ode_growth, 0.0, y, 1, 1e-3, 2000, y);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_RK4, 7.38905609893065, y[0]);
+}
+
+void test_rk4_harmonic_energy_conserved(void)
+{
+    numx_real_t y[] = {1.0, 0.0};
+    numx_real_t E_init  = 0.5*(y[0]*y[0]+y[1]*y[1]);
+    numx_ode_rk4(ode_harmonic, 0.0, y, 2, 1e-3, 1000, y);
+    numx_real_t E_final = 0.5*(y[0]*y[0]+y[1]*y[1]);
+    numx_real_t err = E_final-E_init;
+    if (err < 0.0) err = -err;
+    TEST_ASSERT_TRUE(err < 1e-4);
+}
+
+void test_rk4_single_step(void)
+{
+    numx_real_t y[] = {1.0};
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_ode_rk4(ode_growth, 0.0, y, 1, 0.01, 1, y));
+    TEST_ASSERT_DOUBLE_WITHIN(1e-8, 1.01005016708417, y[0]);
+}
+
+void test_rk4_propagates_rhs_error(void)
+{
+    numx_real_t y[] = {1.0};
+    TEST_ASSERT_EQUAL(NUMX_ERR_SINGULAR,
+                      numx_ode_rk4(ode_error, 0.0, y, 1, 0.1, 10, y));
+}
+
+void test_rk4_null(void)
+{
+    numx_real_t y0[] = {1.0}, y[1];
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_ode_rk4(NULL, 0.0, y0, 1, 0.1, 10, y));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_ode_rk4(ode_growth, 0.0, NULL, 1, 0.1, 10, y));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_ode_rk4(ode_growth, 0.0, y0, 1, 0.1, 10, NULL));
+}
+
+void test_rk4_h_nonpositive(void)
+{
+    numx_real_t y0[] = {1.0}, y[1];
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_ode_rk4(ode_growth, 0.0, y0, 1, 0.0, 10, y));
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_ode_rk4(ode_growth, 0.0, y0, 1, -1.0, 10, y));
+}
+
+void test_rk4_steps_zero(void)
+{
+    numx_real_t y0[] = {1.0}, y[1];
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_ode_rk4(ode_growth, 0.0, y0, 1, 0.1, 0, y));
+}
+
+void test_rk4_n_zero(void)
+{
+    numx_real_t y0[] = {1.0}, y[1];
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_ode_rk4(ode_growth, 0.0, y0, 0, 0.1, 10, y));
+}
+
+void test_rk45_growth_at_t1(void)
+{
+    numx_real_t y[] = {1.0};
+    TEST_ASSERT_EQUAL(NUMX_OK,
+                      numx_ode_rk45(ode_growth, 0.0, 1.0, y, 1, RK45_TOL, y));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_RK45, 2.718281828459045, y[0]);
+}
+
+void test_rk45_decay_at_t1(void)
+{
+    numx_real_t y[] = {1.0};
+    TEST_ASSERT_EQUAL(NUMX_OK,
+                      numx_ode_rk45(ode_decay, 0.0, 1.0, y, 1, RK45_TOL, y));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_RK45, 0.36787944117144233, y[0]);
+}
+
+void test_rk45_harmonic_energy_conserved(void)
+{
+    numx_real_t y[] = {1.0, 0.0};
+    numx_real_t E_init  = 0.5*(y[0]*y[0]+y[1]*y[1]);
+    numx_ode_rk45(ode_harmonic, 0.0, 10.0, y, 2, RK45_TOL, y);
+    numx_real_t E_final = 0.5*(y[0]*y[0]+y[1]*y[1]);
+    numx_real_t err = E_final-E_init;
+    if (err < 0.0) err = -err;
+    TEST_ASSERT_TRUE(err < 1e-4);
+}
+
+void test_rk45_propagates_rhs_error(void)
+{
+    numx_real_t y[] = {1.0};
+    TEST_ASSERT_EQUAL(NUMX_ERR_SINGULAR,
+                      numx_ode_rk45(ode_error, 0.0, 1.0, y, 1, RK45_TOL, y));
+}
+
+void test_rk45_null(void)
+{
+    numx_real_t y0[] = {1.0}, y[1];
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_ode_rk45(NULL, 0.0, 1.0, y0, 1, RK45_TOL, y));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_ode_rk45(ode_growth, 0.0, 1.0, NULL, 1, RK45_TOL, y));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_ode_rk45(ode_growth, 0.0, 1.0, y0, 1, RK45_TOL, NULL));
+}
+
+void test_rk45_t1_le_t0(void)
+{
+    numx_real_t y0[] = {1.0}, y[1];
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_ode_rk45(ode_growth, 1.0, 0.0, y0, 1, RK45_TOL, y));
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_ode_rk45(ode_growth, 1.0, 1.0, y0, 1, RK45_TOL, y));
+}
+
+void test_rk45_tol_nonpositive(void)
+{
+    numx_real_t y0[] = {1.0}, y[1];
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_ode_rk45(ode_growth, 0.0, 1.0, y0, 1, 0.0, y));
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_ode_rk45(ode_growth, 0.0, 1.0, y0, 1, -1e-7, y));
+}
+
+void test_rk45_n_zero(void)
+{
+    numx_real_t y0[] = {1.0}, y[1];
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_ode_rk45(ode_growth, 0.0, 1.0, y0, 0, RK45_TOL, y));
+}
+
+void numx_test_ode(void)
+{
+    RUN_TEST(test_rk4_growth_at_t1);
+    RUN_TEST(test_rk4_decay_at_t1);
+    RUN_TEST(test_rk4_growth_at_t2);
+    RUN_TEST(test_rk4_harmonic_energy_conserved);
+    RUN_TEST(test_rk4_single_step);
+    RUN_TEST(test_rk4_propagates_rhs_error);
+    RUN_TEST(test_rk4_null);
+    RUN_TEST(test_rk4_h_nonpositive);
+    RUN_TEST(test_rk4_steps_zero);
+    RUN_TEST(test_rk4_n_zero);
+    RUN_TEST(test_rk45_growth_at_t1);
+    RUN_TEST(test_rk45_decay_at_t1);
+    RUN_TEST(test_rk45_harmonic_energy_conserved);
+    RUN_TEST(test_rk45_propagates_rhs_error);
+    RUN_TEST(test_rk45_null);
+    RUN_TEST(test_rk45_t1_le_t0);
+    RUN_TEST(test_rk45_tol_nonpositive);
+    RUN_TEST(test_rk45_n_zero);
+}

--- a/tests/x64/test_poly.c
+++ b/tests/x64/test_poly.c
@@ -1,0 +1,174 @@
+/**
+ * @file test_poly.c
+ * @brief Polynomial tests — float64 / x64 host build.
+ *        numx_real_t = double  (compiled with -DNUMX_USE_DOUBLE)
+ */
+
+#include "unity.h"
+#include "numx/numx_types.h"
+#include "numx/poly.h"
+
+#define TOL      1e-9
+#define TOL_ROOT 1e-7
+
+static numx_real_t priv_abs(numx_real_t x){ return x < 0.0 ? -x : x; }
+
+static numx_real_t poly_at(const numx_real_t *c, numx_size_t deg, numx_real_t x)
+{
+    numx_real_t acc = c[0]; numx_size_t i;
+    for (i = 1; i <= deg; i++) acc = acc*x + c[i];
+    return acc;
+}
+
+void test_poly_eval_quadratic_at_3(void)
+{
+    numx_real_t c[] = {1.0,0.0,1.0}, r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_poly_eval(c, 2, 3.0, &r));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 10.0, r);
+}
+
+void test_poly_eval_cubic_at_2(void)
+{
+    numx_real_t c[] = {1.0,0.0,-2.0,1.0}, r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_poly_eval(c, 3, 2.0, &r));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 5.0, r);
+}
+
+void test_poly_eval_at_zero(void)
+{
+    numx_real_t c[] = {3.0,7.0,-2.0}, r;
+    numx_poly_eval(c, 2, 0.0, &r);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, -2.0, r);
+}
+
+void test_poly_eval_at_one(void)
+{
+    numx_real_t c[] = {1.0,-3.0,2.0}, r;
+    numx_poly_eval(c, 2, 1.0, &r);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 0.0, r);
+}
+
+void test_poly_eval_degree_0(void)
+{
+    numx_real_t c[] = {5.0}, r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_poly_eval(c, 0, 99.0, &r));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 5.0, r);
+}
+
+void test_poly_eval_horner_consistency(void)
+{
+    numx_real_t c[] = {2.0,3.0,4.0}, r;
+    numx_poly_eval(c, 2, 5.0, &r);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 69.0, r);
+}
+
+void test_poly_eval_null_coeffs(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_poly_eval(NULL, 2, 1.0, &r));
+}
+
+void test_poly_eval_null_result(void)
+{
+    numx_real_t c[] = {1.0,0.0,0.0};
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_poly_eval(c, 2, 1.0, NULL));
+}
+
+void test_poly_roots_linear(void)
+{
+    numx_real_t c[] = {1.0,1.0};
+    numx_real_t roots[1]; numx_size_t nroots;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_poly_roots(c, 1, roots, &nroots, TOL_ROOT));
+    TEST_ASSERT_EQUAL(1, (int)nroots);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, -1.0, roots[0]);
+}
+
+void test_poly_roots_quadratic_two_reals(void)
+{
+    numx_real_t c[] = {1.0,-5.0,6.0};
+    numx_real_t roots[2]; numx_size_t nroots;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_poly_roots(c, 2, roots, &nroots, TOL_ROOT));
+    TEST_ASSERT_EQUAL(2, (int)nroots);
+    TEST_ASSERT_DOUBLE_WITHIN(1e-6, 0.0, poly_at(c, 2, roots[0]));
+    TEST_ASSERT_DOUBLE_WITHIN(1e-6, 0.0, poly_at(c, 2, roots[1]));
+}
+
+void test_poly_roots_quadratic_root_values(void)
+{
+    numx_real_t c[] = {1.0,-5.0,6.0};
+    numx_real_t roots[2]; numx_size_t nroots;
+    numx_real_t lo, hi, tmp;
+    numx_poly_roots(c, 2, roots, &nroots, TOL_ROOT);
+    lo = roots[0]; hi = roots[1];
+    if (lo > hi) { tmp=lo; lo=hi; hi=tmp; }
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 2.0, lo);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 3.0, hi);
+}
+
+void test_poly_roots_cubic_residuals(void)
+{
+    numx_real_t c[] = {1.0,-6.0,11.0,-6.0};
+    numx_real_t roots[3]; numx_size_t nroots, i;
+    numx_poly_roots(c, 3, roots, &nroots, TOL_ROOT);
+    for (i = 0; i < nroots; i++)
+        TEST_ASSERT_TRUE(priv_abs(poly_at(c, 3, roots[i])) < 1e-6);
+}
+
+void test_poly_roots_single_real_found(void)
+{
+    numx_real_t c[] = {1.0,0.0,0.0,-8.0};
+    numx_real_t roots[3]; numx_size_t nroots; int found = 0; numx_size_t i;
+    numx_poly_roots(c, 3, roots, &nroots, TOL_ROOT);
+    TEST_ASSERT_TRUE(nroots >= 1);
+    for (i = 0; i < nroots; i++)
+        if (priv_abs(roots[i]-2.0) < 1e-5) found = 1;
+    TEST_ASSERT_TRUE(found);
+}
+
+void test_poly_roots_null(void)
+{
+    numx_real_t c[] = {1.0,0.0,-1.0};
+    numx_real_t roots[2]; numx_size_t nroots;
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_poly_roots(NULL, 2, roots, &nroots, TOL_ROOT));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_poly_roots(c, 2, NULL, &nroots, TOL_ROOT));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_poly_roots(c, 2, roots, NULL, TOL_ROOT));
+}
+
+void test_poly_roots_degree_zero_rejected(void)
+{
+    numx_real_t c[] = {1.0};
+    numx_real_t roots[1]; numx_size_t nroots;
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_poly_roots(c, 0, roots, &nroots, TOL_ROOT));
+}
+
+void test_poly_roots_tol_nonpositive(void)
+{
+    numx_real_t c[] = {1.0,-1.0};
+    numx_real_t roots[1]; numx_size_t nroots;
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_poly_roots(c, 1, roots, &nroots, 0.0));
+}
+
+void numx_test_poly(void)
+{
+    RUN_TEST(test_poly_eval_quadratic_at_3);
+    RUN_TEST(test_poly_eval_cubic_at_2);
+    RUN_TEST(test_poly_eval_at_zero);
+    RUN_TEST(test_poly_eval_at_one);
+    RUN_TEST(test_poly_eval_degree_0);
+    RUN_TEST(test_poly_eval_horner_consistency);
+    RUN_TEST(test_poly_eval_null_coeffs);
+    RUN_TEST(test_poly_eval_null_result);
+    RUN_TEST(test_poly_roots_linear);
+    RUN_TEST(test_poly_roots_quadratic_two_reals);
+    RUN_TEST(test_poly_roots_quadratic_root_values);
+    RUN_TEST(test_poly_roots_cubic_residuals);
+    RUN_TEST(test_poly_roots_single_real_found);
+    RUN_TEST(test_poly_roots_null);
+    RUN_TEST(test_poly_roots_degree_zero_rejected);
+    RUN_TEST(test_poly_roots_tol_nonpositive);
+}

--- a/tests/x64/test_roots.c
+++ b/tests/x64/test_roots.c
@@ -1,0 +1,237 @@
+/**
+ * @file test_roots.c
+ * @brief Root-finding tests — float64 / x64 host build.
+ *        numx_real_t = double  (compiled with -DNUMX_USE_DOUBLE)
+ */
+
+#include "unity.h"
+#include "numx/numx_types.h"
+#include "numx/roots.h"
+
+#define TOL      1e-10
+#define ROOT_TOL 1e-10
+
+static numx_real_t f_linear(numx_real_t x)    { return x - (numx_real_t)2.0; }
+static numx_real_t df_linear(numx_real_t x)   { (void)x; return (numx_real_t)1.0; }
+static numx_real_t f_quadratic(numx_real_t x) { return x*x - (numx_real_t)4.0; }
+static numx_real_t df_quadratic(numx_real_t x){ return (numx_real_t)2.0*x; }
+static numx_real_t f_cubic(numx_real_t x)     { return x*x*x - x; }
+static numx_real_t df_cubic(numx_real_t x)    { return (numx_real_t)3.0*x*x - (numx_real_t)1.0; }
+
+static numx_real_t f_double_root(numx_real_t x)
+{ numx_real_t d = x-(numx_real_t)1.0; return d*d; }
+static numx_real_t df_double_root(numx_real_t x)
+{ return (numx_real_t)2.0*(x-(numx_real_t)1.0); }
+
+void test_bisect_linear(void)
+{
+    numx_real_t root;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_root_bisect(f_linear, 0.0, 5.0, ROOT_TOL, &root));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 2.0, root);
+}
+
+void test_bisect_quadratic_positive(void)
+{
+    numx_real_t root;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_root_bisect(f_quadratic, 0.0, 5.0, ROOT_TOL, &root));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 2.0, root);
+}
+
+void test_bisect_quadratic_negative(void)
+{
+    numx_real_t root;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_root_bisect(f_quadratic, -5.0, 0.0, ROOT_TOL, &root));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, -2.0, root);
+}
+
+void test_bisect_residual_near_zero(void)
+{
+    numx_real_t root, residual;
+    numx_root_bisect(f_cubic, 0.5, 2.0, ROOT_TOL, &root);
+    residual = f_cubic(root);
+    if (residual < 0.0) residual = -residual;
+    TEST_ASSERT_TRUE(residual < 1e-6);
+}
+
+void test_bisect_root_at_left_endpoint(void)
+{
+    numx_real_t root;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_root_bisect(f_linear, 2.0, 5.0, ROOT_TOL, &root));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 2.0, root);
+}
+
+void test_bisect_root_at_right_endpoint(void)
+{
+    numx_real_t root;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_root_bisect(f_linear, 0.0, 2.0, ROOT_TOL, &root));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 2.0, root);
+}
+
+void test_bisect_null_f(void)
+{
+    numx_real_t root;
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_root_bisect(NULL, 0.0, 1.0, ROOT_TOL, &root));
+}
+
+void test_bisect_null_root(void)
+{
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_root_bisect(f_linear, 0.0, 5.0, ROOT_TOL, NULL));
+}
+
+void test_bisect_no_bracket(void)
+{
+    numx_real_t root;
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_root_bisect(f_quadratic, 3.0, 5.0, ROOT_TOL, &root));
+}
+
+void test_bisect_tol_zero(void)
+{
+    numx_real_t root;
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_root_bisect(f_linear, 0.0, 5.0, 0.0, &root));
+}
+
+void test_newton_linear(void)
+{
+    numx_real_t root;
+    TEST_ASSERT_EQUAL(NUMX_OK,
+                      numx_root_newton(f_linear, df_linear, 0.0, ROOT_TOL, &root));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 2.0, root);
+}
+
+void test_newton_quadratic(void)
+{
+    numx_real_t root;
+    TEST_ASSERT_EQUAL(NUMX_OK,
+                      numx_root_newton(f_quadratic, df_quadratic, 3.0, ROOT_TOL, &root));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 2.0, root);
+}
+
+void test_newton_residual_near_zero(void)
+{
+    numx_real_t root, res;
+    numx_root_newton(f_cubic, df_cubic, 2.0, ROOT_TOL, &root);
+    res = f_cubic(root);
+    if (res < 0.0) res = -res;
+    TEST_ASSERT_TRUE(res < 1e-6);
+}
+
+void test_newton_already_at_root(void)
+{
+    numx_real_t root;
+    TEST_ASSERT_EQUAL(NUMX_OK,
+                      numx_root_newton(f_linear, df_linear, 2.0, ROOT_TOL, &root));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 2.0, root);
+}
+
+void test_newton_null_f(void)
+{
+    numx_real_t root;
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_root_newton(NULL, df_linear, 0.0, ROOT_TOL, &root));
+}
+
+void test_newton_null_df(void)
+{
+    numx_real_t root;
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_root_newton(f_linear, NULL, 0.0, ROOT_TOL, &root));
+}
+
+void test_newton_zero_derivative(void)
+{
+    numx_real_t root;
+    numx_status_t s = numx_root_newton(f_double_root, df_double_root,
+                                       1.0, ROOT_TOL, &root);
+    TEST_ASSERT_TRUE(s == NUMX_OK || s == NUMX_ERR_SINGULAR);
+}
+
+void test_newton_tol_negative(void)
+{
+    numx_real_t root;
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_root_newton(f_linear, df_linear, 0.0, -1.0, &root));
+}
+
+void test_brent_linear(void)
+{
+    numx_real_t root;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_root_brent(f_linear, 0.0, 5.0, ROOT_TOL, &root));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 2.0, root);
+}
+
+void test_brent_quadratic(void)
+{
+    numx_real_t root;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_root_brent(f_quadratic, 0.0, 5.0, ROOT_TOL, &root));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 2.0, root);
+}
+
+void test_brent_cubic_root_at_one(void)
+{
+    numx_real_t root;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_root_brent(f_cubic, 0.5, 1.5, ROOT_TOL, &root));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 1.0, root);
+}
+
+void test_brent_residual_near_zero(void)
+{
+    numx_real_t root, res;
+    numx_root_brent(f_cubic, -1.5, -0.5, ROOT_TOL, &root);
+    res = f_cubic(root);
+    if (res < 0.0) res = -res;
+    TEST_ASSERT_TRUE(res < 1e-6);
+}
+
+void test_brent_null(void)
+{
+    numx_real_t root;
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_root_brent(NULL, 0.0, 5.0, ROOT_TOL, &root));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_root_brent(f_linear, 0.0, 5.0, ROOT_TOL, NULL));
+}
+
+void test_brent_no_bracket(void)
+{
+    numx_real_t root;
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_root_brent(f_quadratic, 3.0, 5.0, ROOT_TOL, &root));
+}
+
+void test_brent_tol_zero(void)
+{
+    numx_real_t root;
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_root_brent(f_linear, 0.0, 5.0, 0.0, &root));
+}
+
+void numx_test_roots(void)
+{
+    RUN_TEST(test_bisect_linear);
+    RUN_TEST(test_bisect_quadratic_positive);
+    RUN_TEST(test_bisect_quadratic_negative);
+    RUN_TEST(test_bisect_residual_near_zero);
+    RUN_TEST(test_bisect_root_at_left_endpoint);
+    RUN_TEST(test_bisect_root_at_right_endpoint);
+    RUN_TEST(test_bisect_null_f);
+    RUN_TEST(test_bisect_null_root);
+    RUN_TEST(test_bisect_no_bracket);
+    RUN_TEST(test_bisect_tol_zero);
+    RUN_TEST(test_newton_linear);
+    RUN_TEST(test_newton_quadratic);
+    RUN_TEST(test_newton_residual_near_zero);
+    RUN_TEST(test_newton_already_at_root);
+    RUN_TEST(test_newton_null_f);
+    RUN_TEST(test_newton_null_df);
+    RUN_TEST(test_newton_zero_derivative);
+    RUN_TEST(test_newton_tol_negative);
+    RUN_TEST(test_brent_linear);
+    RUN_TEST(test_brent_quadratic);
+    RUN_TEST(test_brent_cubic_root_at_one);
+    RUN_TEST(test_brent_residual_near_zero);
+    RUN_TEST(test_brent_null);
+    RUN_TEST(test_brent_no_bracket);
+    RUN_TEST(test_brent_tol_zero);
+}

--- a/tests/x64/test_runner.c
+++ b/tests/x64/test_runner.c
@@ -1,0 +1,47 @@
+/**
+ * @file test_runner.c
+ * @brief numx master test runner — float64 / x64 host build.
+ *
+ * Compile with the CMakeLists.txt in this directory.
+ * numx_real_t = double (compiled with -DNUMX_USE_DOUBLE).
+ */
+
+#include "unity.h"
+
+void numx_test_linalg(void);
+void numx_test_stats(void);
+void numx_test_roots(void);
+void numx_test_integrate(void);
+void numx_test_differentiate(void);
+void numx_test_interpolate(void);
+void numx_test_poly(void);
+void numx_test_ode(void);
+void numx_test_signal(void);
+void numx_test_fft(void);
+void numx_test_autodiff(void);
+void numx_test_compressed_sensing(void);
+void numx_test_sketch(void);
+
+void setUp(void) {}
+void tearDown(void) {}
+
+int main(void)
+{
+    UNITY_BEGIN();
+
+    numx_test_linalg();
+    numx_test_stats();
+    numx_test_roots();
+    numx_test_integrate();
+    numx_test_differentiate();
+    numx_test_interpolate();
+    numx_test_poly();
+    numx_test_ode();
+    numx_test_signal();
+    numx_test_fft();
+    numx_test_autodiff();
+    numx_test_compressed_sensing();
+    numx_test_sketch();
+
+    return UNITY_END();
+}

--- a/tests/x64/test_signal.c
+++ b/tests/x64/test_signal.c
@@ -1,0 +1,279 @@
+/**
+ * @file test_signal.c
+ * @brief Signal processing tests — float64 / x64 host build.
+ *        numx_real_t = double  (compiled with -DNUMX_USE_DOUBLE)
+ */
+
+#include "unity.h"
+#include "numx/signal.h"
+
+#define TOL 1e-9
+
+void test_window_rect_all_ones(void)
+{
+    numx_real_t w[8]; numx_size_t i;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_signal_window_rect(8, w));
+    for (i = 0; i < 8; i++) TEST_ASSERT_DOUBLE_WITHIN(TOL, 1.0, w[i]);
+}
+
+void test_window_rect_n1(void)
+{
+    numx_real_t w[1];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_signal_window_rect(1, w));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 1.0, w[0]);
+}
+
+void test_window_hann_endpoints_zero(void)
+{
+    numx_real_t w[5];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_signal_window_hann(5, w));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 0.0, w[0]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 0.0, w[4]);
+}
+
+void test_window_hann_midpoint_one(void)
+{
+    numx_real_t w[5];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_signal_window_hann(5, w));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 1.0, w[2]);
+}
+
+void test_window_hann_n1_returns_one(void)
+{
+    numx_real_t w[1];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_signal_window_hann(1, w));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 1.0, w[0]);
+}
+
+void test_window_hamming_endpoints(void)
+{
+    numx_real_t w[5];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_signal_window_hamming(5, w));
+    TEST_ASSERT_DOUBLE_WITHIN(1e-7, 0.08, w[0]);
+    TEST_ASSERT_DOUBLE_WITHIN(1e-7, 0.08, w[4]);
+}
+
+void test_window_hamming_midpoint_one(void)
+{
+    numx_real_t w[5];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_signal_window_hamming(5, w));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 1.0, w[2]);
+}
+
+void test_window_blackman_endpoints_zero(void)
+{
+    numx_real_t w[5];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_signal_window_blackman(5, w));
+    TEST_ASSERT_DOUBLE_WITHIN(1e-9, 0.0, w[0]);
+    TEST_ASSERT_DOUBLE_WITHIN(1e-9, 0.0, w[4]);
+}
+
+void test_window_blackman_midpoint_one(void)
+{
+    numx_real_t w[5];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_signal_window_blackman(5, w));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 1.0, w[2]);
+}
+
+void test_convolve_box(void)
+{
+    numx_real_t x[] = {1.0,1.0,1.0}, h[] = {1.0,1.0,1.0}, out[5];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_signal_convolve(x, 3, h, 3, out));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 1.0, out[0]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 2.0, out[1]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 3.0, out[2]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 2.0, out[3]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 1.0, out[4]);
+}
+
+void test_convolve_unit_impulse(void)
+{
+    numx_real_t x[] = {1.0,0.0,0.0}, h[] = {3.0,2.0,1.0}, out[5];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_signal_convolve(x, 3, h, 3, out));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 3.0, out[0]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 2.0, out[1]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 1.0, out[2]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 0.0, out[3]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 0.0, out[4]);
+}
+
+void test_convolve_null_returns_error(void)
+{
+    numx_real_t x[2]={0},h[2]={0},out[3]={0};
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_signal_convolve(NULL,2,h,2,out));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_signal_convolve(x,2,NULL,2,out));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_signal_convolve(x,2,h,2,NULL));
+}
+
+void test_correlate_autocorr_peak_at_lag0(void)
+{
+    numx_real_t x[] = {1.0,1.0,1.0}, out[5];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_signal_correlate(x, 3, x, 3, out));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 3.0, out[2]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 2.0, out[1]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 2.0, out[3]);
+}
+
+void test_correlate_output_length(void)
+{
+    numx_real_t x[] = {1.0,2.0}, y[] = {1.0,0.0,0.0}, out[4];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_signal_correlate(x, 2, y, 3, out));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 0.0, out[0]);
+}
+
+void test_fir_identity_tap(void)
+{
+    numx_real_t x[] = {1.0,2.0,3.0}, taps[] = {1.0}, out[3];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_signal_fir(x, 3, taps, 1, out));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 1.0, out[0]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 2.0, out[1]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 3.0, out[2]);
+}
+
+void test_fir_moving_average(void)
+{
+    numx_real_t x[] = {3.0,3.0,3.0,3.0,3.0};
+    numx_real_t third = 1.0/3.0;
+    numx_real_t taps[] = {third,third,third}, out[5];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_signal_fir(x, 5, taps, 3, out));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 1.0, out[0]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 2.0, out[1]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 3.0, out[2]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 3.0, out[3]);
+}
+
+void test_fir_null_returns_error(void)
+{
+    numx_real_t x[2]={0},taps[1]={1.0},out[2]={0};
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_signal_fir(NULL,2,taps,1,out));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_signal_fir(x,2,NULL,1,out));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_signal_fir(x,2,taps,1,NULL));
+}
+
+void test_iir_biquad_identity(void)
+{
+    numx_real_t x[]={1.0,2.0,3.0},b[]={1.0,0.0,0.0},a[]={0.0,0.0},out[3];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_signal_iir_biquad(x,3,b,a,out));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 1.0, out[0]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 2.0, out[1]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 3.0, out[2]);
+}
+
+void test_iir_biquad_scale(void)
+{
+    numx_real_t x[]={1.0,2.0,3.0},b[]={2.0,0.0,0.0},a[]={0.0,0.0},out[3];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_signal_iir_biquad(x,3,b,a,out));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 2.0, out[0]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 4.0, out[1]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 6.0, out[2]);
+}
+
+void test_iir_biquad_null_returns_error(void)
+{
+    numx_real_t x[2]={0},b[]={1,0,0},a[]={0,0},out[2]={0};
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_signal_iir_biquad(NULL,2,b,a,out));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_signal_iir_biquad(x,2,NULL,a,out));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_signal_iir_biquad(x,2,b,NULL,out));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_signal_iir_biquad(x,2,b,a,NULL));
+}
+
+void test_peaks_two_peaks(void)
+{
+    numx_real_t x[] = {0.0,1.0,0.0,2.0,0.0};
+    numx_size_t peaks[5], npeaks;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_signal_peaks(x, 5, peaks, 5, &npeaks));
+    TEST_ASSERT_EQUAL(2, npeaks);
+    TEST_ASSERT_EQUAL(1, peaks[0]);
+    TEST_ASSERT_EQUAL(3, peaks[1]);
+}
+
+void test_peaks_monotone_no_peaks(void)
+{
+    numx_real_t x[] = {1.0,2.0,3.0,4.0,5.0};
+    numx_size_t peaks[5], npeaks;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_signal_peaks(x, 5, peaks, 5, &npeaks));
+    TEST_ASSERT_EQUAL(0, npeaks);
+}
+
+void test_peaks_short_signal_no_peaks(void)
+{
+    numx_real_t x[] = {5.0,5.0};
+    numx_size_t peaks[2], npeaks;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_signal_peaks(x, 2, peaks, 2, &npeaks));
+    TEST_ASSERT_EQUAL(0, npeaks);
+}
+
+void test_peaks_buffer_too_small(void)
+{
+    numx_real_t x[] = {0.0,1.0,0.0,2.0,0.0};
+    numx_size_t peaks[1], npeaks;
+    TEST_ASSERT_EQUAL(NUMX_ERR_BUFFER_SMALL, numx_signal_peaks(x, 5, peaks, 1, &npeaks));
+}
+
+void test_ema_alpha1_copies_input(void)
+{
+    numx_real_t x[] = {1.0,2.0,3.0}, out[3];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_signal_ema(x, 3, 1.0, out));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 1.0, out[0]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 2.0, out[1]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 3.0, out[2]);
+}
+
+void test_ema_alpha0_stays_at_first(void)
+{
+    numx_real_t x[] = {5.0,1.0,1.0,1.0}, out[4];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_signal_ema(x, 4, 0.0, out));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 5.0, out[0]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 5.0, out[1]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 5.0, out[2]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 5.0, out[3]);
+}
+
+void test_ema_known_sequence(void)
+{
+    numx_real_t x[] = {0.0,1.0,0.0,0.0}, out[4];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_signal_ema(x, 4, 0.5, out));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 0.0,   out[0]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 0.5,   out[1]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 0.25,  out[2]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 0.125, out[3]);
+}
+
+void test_ema_invalid_alpha_returns_error(void)
+{
+    numx_real_t x[2]={0}, out[2];
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_signal_ema(x, 2, -0.1, out));
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_signal_ema(x, 2,  1.1, out));
+}
+
+void numx_test_signal(void)
+{
+    RUN_TEST(test_window_rect_all_ones);
+    RUN_TEST(test_window_rect_n1);
+    RUN_TEST(test_window_hann_endpoints_zero);
+    RUN_TEST(test_window_hann_midpoint_one);
+    RUN_TEST(test_window_hann_n1_returns_one);
+    RUN_TEST(test_window_hamming_endpoints);
+    RUN_TEST(test_window_hamming_midpoint_one);
+    RUN_TEST(test_window_blackman_endpoints_zero);
+    RUN_TEST(test_window_blackman_midpoint_one);
+    RUN_TEST(test_convolve_box);
+    RUN_TEST(test_convolve_unit_impulse);
+    RUN_TEST(test_convolve_null_returns_error);
+    RUN_TEST(test_correlate_autocorr_peak_at_lag0);
+    RUN_TEST(test_correlate_output_length);
+    RUN_TEST(test_fir_identity_tap);
+    RUN_TEST(test_fir_moving_average);
+    RUN_TEST(test_fir_null_returns_error);
+    RUN_TEST(test_iir_biquad_identity);
+    RUN_TEST(test_iir_biquad_scale);
+    RUN_TEST(test_iir_biquad_null_returns_error);
+    RUN_TEST(test_peaks_two_peaks);
+    RUN_TEST(test_peaks_monotone_no_peaks);
+    RUN_TEST(test_peaks_short_signal_no_peaks);
+    RUN_TEST(test_peaks_buffer_too_small);
+    RUN_TEST(test_ema_alpha1_copies_input);
+    RUN_TEST(test_ema_alpha0_stays_at_first);
+    RUN_TEST(test_ema_known_sequence);
+    RUN_TEST(test_ema_invalid_alpha_returns_error);
+}

--- a/tests/x64/test_sketch.c
+++ b/tests/x64/test_sketch.c
@@ -1,0 +1,112 @@
+/**
+ * @file test_sketch.c
+ * @brief Randomized SVD tests — float64 / x64 host build.
+ *        numx_real_t = double  (compiled with -DNUMX_USE_DOUBLE)
+ *
+ * Tolerances remain loose: rSVD is a randomized algorithm and reconstruction
+ * quality is bounded by algorithm design, not floating-point precision.
+ */
+
+#include "unity.h"
+#include "numx/sketch.h"
+
+#define TOL_RECON 0.5
+#define TOL_SV    0.2
+
+static numx_real_t recon_err_sq(
+    const numx_real_t *A,
+    const numx_real_t *U, const numx_real_t *S, const numx_real_t *Vt,
+    numx_size_t m, numx_size_t n, numx_size_t rank)
+{
+    numx_size_t i, j, k;
+    numx_real_t val, diff, err = (numx_real_t)0.0;
+    for (i = 0; i < m; i++)
+        for (j = 0; j < n; j++)
+        {
+            val = (numx_real_t)0.0;
+            for (k = 0; k < rank; k++)
+                val += U[i*rank+k]*S[k]*Vt[k*n+j];
+            diff = A[i*n+j]-val;
+            err += diff*diff;
+        }
+    return err;
+}
+
+void test_rsvd_rank1_reconstruction(void)
+{
+    numx_real_t A[6]  = {4.0,0.0, 0.0,0.0, 0.0,0.0};
+    numx_real_t U[3]  = {0};
+    numx_real_t S[1]  = {0};
+    numx_real_t Vt[2] = {0};
+    TEST_ASSERT_EQUAL(NUMX_OK,
+        numx_sketch_rsvd(A, 3, 2, 1, 1, 42u, U, S, Vt));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_SV, 4.0, S[0]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_RECON, 0.0,
+        recon_err_sq(A, U, S, Vt, 3, 2, 1));
+}
+
+void test_rsvd_diagonal_rank2(void)
+{
+    numx_real_t A[16] = {
+        3.0,0.0,0.0,0.0,
+        0.0,2.0,0.0,0.0,
+        0.0,0.0,0.0,0.0,
+        0.0,0.0,0.0,0.0
+    };
+    numx_real_t U[8]  = {0};
+    numx_real_t S[2]  = {0};
+    numx_real_t Vt[8] = {0};
+    TEST_ASSERT_EQUAL(NUMX_OK,
+        numx_sketch_rsvd(A, 4, 4, 2, 2, 42u, U, S, Vt));
+    TEST_ASSERT_TRUE(S[0] >= S[1]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_SV, 3.0, S[0]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_SV, 2.0, S[1]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_RECON, 0.0,
+        recon_err_sq(A, U, S, Vt, 4, 4, 2));
+}
+
+void test_rsvd_tall_matrix(void)
+{
+    numx_real_t A[6]  = {1,0, 1,0, 1,0};
+    numx_real_t U[3]  = {0};
+    numx_real_t S[1]  = {0};
+    numx_real_t Vt[2] = {0};
+    TEST_ASSERT_EQUAL(NUMX_OK,
+        numx_sketch_rsvd(A, 3, 2, 1, 1, 7u, U, S, Vt));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_SV, 1.732050808, S[0]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL_RECON, 0.0,
+        recon_err_sq(A, U, S, Vt, 3, 2, 1));
+}
+
+void test_rsvd_null_returns_error(void)
+{
+    numx_real_t A[4]={0},U[2]={0},S[1]={0},Vt[2]={0};
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+        numx_sketch_rsvd(NULL,2,2,1,1,1u,U,S,Vt));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+        numx_sketch_rsvd(A,2,2,1,1,1u,NULL,S,Vt));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+        numx_sketch_rsvd(A,2,2,1,1,1u,U,NULL,Vt));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+        numx_sketch_rsvd(A,2,2,1,1,1u,U,S,NULL));
+}
+
+void test_rsvd_invalid_arg_returns_error(void)
+{
+    numx_real_t A[4]={0},U[2]={0},S[1]={0},Vt[2]={0};
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+        numx_sketch_rsvd(A,2,2,0,1,1u,U,S,Vt));
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+        numx_sketch_rsvd(A,0,2,1,1,1u,U,S,Vt));
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+        numx_sketch_rsvd(A,2,2,NUMX_MAX_SKETCH_RANK,1,1u,U,S,Vt));
+}
+
+void numx_test_sketch(void)
+{
+    RUN_TEST(test_rsvd_rank1_reconstruction);
+    RUN_TEST(test_rsvd_diagonal_rank2);
+    RUN_TEST(test_rsvd_tall_matrix);
+    RUN_TEST(test_rsvd_null_returns_error);
+    RUN_TEST(test_rsvd_invalid_arg_returns_error);
+}

--- a/tests/x64/test_stats.c
+++ b/tests/x64/test_stats.c
@@ -1,0 +1,246 @@
+/**
+ * @file test_stats.c
+ * @brief Statistics tests — float64 / x64 host build.
+ *        numx_real_t = double  (compiled with -DNUMX_USE_DOUBLE)
+ */
+
+#include "unity.h"
+#include "numx/numx_types.h"
+#include "numx/stats.h"
+
+#define TOL 1e-9
+
+void test_stats_mean_known(void)
+{
+    numx_real_t a[] = {1.0,2.0,3.0,4.0,5.0};
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_stats_mean(a, 5, &r));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 3.0, r);
+}
+
+void test_stats_mean_negative_values(void)
+{
+    numx_real_t a[] = {-3.0,-1.0,1.0,3.0};
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_stats_mean(a, 4, &r));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 0.0, r);
+}
+
+void test_stats_mean_arithmetic_sequence(void)
+{
+    numx_real_t a[] = {1.0,2.0,3.0,4.0,5.0,6.0,7.0};
+    numx_real_t r;
+    numx_stats_mean(a, 7, &r);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 4.0, r);
+}
+
+void test_stats_mean_constant_array(void)
+{
+    numx_real_t a[] = {5.0,5.0,5.0,5.0};
+    numx_real_t r;
+    numx_stats_mean(a, 4, &r);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 5.0, r);
+}
+
+void test_stats_mean_single_element(void)
+{
+    numx_real_t a[] = {42.0};
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_stats_mean(a, 1, &r));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 42.0, r);
+}
+
+void test_stats_mean_null_a(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_stats_mean(NULL, 3, &r));
+}
+
+void test_stats_mean_null_result(void)
+{
+    numx_real_t a[] = {1.0,2.0};
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_stats_mean(a, 2, NULL));
+}
+
+void test_stats_mean_n_zero(void)
+{
+    numx_real_t a[] = {1.0}, r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_stats_mean(a, 0, &r));
+}
+
+void test_stats_variance_pop_known(void)
+{
+    numx_real_t a[] = {2.0,4.0,4.0,4.0,5.0,5.0,7.0,9.0};
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_stats_variance(a, 8, NUMX_VAR_POPULATION, &r));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 4.0, r);
+}
+
+void test_stats_variance_sample_known(void)
+{
+    numx_real_t a[] = {2.0,4.0,4.0,4.0,5.0,5.0,7.0,9.0};
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_stats_variance(a, 8, NUMX_VAR_SAMPLE, &r));
+    TEST_ASSERT_DOUBLE_WITHIN(1e-8, 32.0/7.0, r);
+}
+
+void test_stats_variance_constant_is_zero(void)
+{
+    numx_real_t a[] = {7.0,7.0,7.0,7.0};
+    numx_real_t r;
+    numx_stats_variance(a, 4, NUMX_VAR_POPULATION, &r);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 0.0, r);
+}
+
+void test_stats_variance_sample_ge_population(void)
+{
+    numx_real_t a[] = {1.0,2.0,3.0,4.0,5.0};
+    numx_real_t rpop, rsamp;
+    numx_stats_variance(a, 5, NUMX_VAR_POPULATION, &rpop);
+    numx_stats_variance(a, 5, NUMX_VAR_SAMPLE, &rsamp);
+    TEST_ASSERT_TRUE(rsamp > rpop);
+}
+
+void test_stats_variance_sample_n1_rejected(void)
+{
+    numx_real_t a[] = {1.0}, r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_stats_variance(a, 1, NUMX_VAR_SAMPLE, &r));
+}
+
+void test_stats_variance_null(void)
+{
+    numx_real_t a[] = {1.0,2.0}, r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_stats_variance(NULL, 2, NUMX_VAR_POPULATION, &r));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_stats_variance(a, 2, NUMX_VAR_POPULATION, NULL));
+}
+
+void test_stats_median_odd_known(void)
+{
+    numx_real_t a[] = {5.0,3.0,1.0,4.0,2.0};
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_stats_median(a, 5, &r));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 3.0, r);
+}
+
+void test_stats_median_even_known(void)
+{
+    numx_real_t a[] = {4.0,1.0,3.0,2.0};
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_stats_median(a, 4, &r));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 2.5, r);
+}
+
+void test_stats_median_sorted_middle(void)
+{
+    numx_real_t a[] = {10.0,20.0,30.0,40.0,50.0};
+    numx_real_t r;
+    numx_stats_median(a, 5, &r);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 30.0, r);
+}
+
+void test_stats_median_does_not_modify_input(void)
+{
+    numx_real_t a[] = {5.0,3.0,1.0};
+    numx_real_t r;
+    numx_stats_median(a, 3, &r);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 5.0, a[0]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 3.0, a[1]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 1.0, a[2]);
+}
+
+void test_stats_median_single_element(void)
+{
+    numx_real_t a[] = {7.0};
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_stats_median(a, 1, &r));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 7.0, r);
+}
+
+void test_stats_median_two_elements(void)
+{
+    numx_real_t a[] = {3.0,1.0};
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_stats_median(a, 2, &r));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 2.0, r);
+}
+
+void test_stats_median_null(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_stats_median(NULL, 3, &r));
+    numx_real_t a[] = {1.0};
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_stats_median(a, 1, NULL));
+}
+
+void test_stats_percentile_0_is_min(void)
+{
+    numx_real_t a[] = {5.0,3.0,1.0,4.0,2.0};
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_stats_percentile(a, 5, 0.0, &r));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 1.0, r);
+}
+
+void test_stats_percentile_100_is_max(void)
+{
+    numx_real_t a[] = {5.0,3.0,1.0,4.0,2.0};
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_stats_percentile(a, 5, 100.0, &r));
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 5.0, r);
+}
+
+void test_stats_percentile_does_not_modify_input(void)
+{
+    numx_real_t a[] = {3.0,1.0,2.0};
+    numx_real_t r;
+    numx_stats_percentile(a, 3, 50.0, &r);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 3.0, a[0]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 1.0, a[1]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 2.0, a[2]);
+}
+
+void test_stats_percentile_null(void)
+{
+    numx_real_t a[] = {1.0,2.0}, r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_stats_percentile(NULL, 2, 50.0, &r));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_stats_percentile(a, 2, 50.0, NULL));
+}
+
+void test_stats_percentile_out_of_range(void)
+{
+    numx_real_t a[] = {1.0,2.0,3.0}, r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_stats_percentile(a, 3, -1.0, &r));
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_stats_percentile(a, 3, 101.0, &r));
+}
+
+void numx_test_stats(void)
+{
+    RUN_TEST(test_stats_mean_known);
+    RUN_TEST(test_stats_mean_negative_values);
+    RUN_TEST(test_stats_mean_arithmetic_sequence);
+    RUN_TEST(test_stats_mean_constant_array);
+    RUN_TEST(test_stats_mean_single_element);
+    RUN_TEST(test_stats_mean_null_a);
+    RUN_TEST(test_stats_mean_null_result);
+    RUN_TEST(test_stats_mean_n_zero);
+    RUN_TEST(test_stats_variance_pop_known);
+    RUN_TEST(test_stats_variance_sample_known);
+    RUN_TEST(test_stats_variance_constant_is_zero);
+    RUN_TEST(test_stats_variance_sample_ge_population);
+    RUN_TEST(test_stats_variance_sample_n1_rejected);
+    RUN_TEST(test_stats_variance_null);
+    RUN_TEST(test_stats_median_odd_known);
+    RUN_TEST(test_stats_median_even_known);
+    RUN_TEST(test_stats_median_sorted_middle);
+    RUN_TEST(test_stats_median_does_not_modify_input);
+    RUN_TEST(test_stats_median_single_element);
+    RUN_TEST(test_stats_median_two_elements);
+    RUN_TEST(test_stats_median_null);
+    RUN_TEST(test_stats_percentile_0_is_min);
+    RUN_TEST(test_stats_percentile_100_is_max);
+    RUN_TEST(test_stats_percentile_does_not_modify_input);
+    RUN_TEST(test_stats_percentile_null);
+    RUN_TEST(test_stats_percentile_out_of_range);
+}

--- a/tests/x86/CMakeLists.txt
+++ b/tests/x86/CMakeLists.txt
@@ -1,0 +1,113 @@
+cmake_minimum_required(VERSION 3.15)
+project(numx_tests_x86 C)
+
+# Host-native float32 tests — NOT for ESP32.
+# numx_real_t = float (NUMX_USE_DOUBLE is NOT set).
+# To build 32-bit on a 64-bit host pass -DNUMX_FORCE_32BIT=ON; this requires
+# multilib support (gcc-multilib / clang -m32 / MSVC Win32 generator).
+
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+
+set(NUMX_INC  ${CMAKE_CURRENT_SOURCE_DIR}/../../include)
+set(NUMX_SRC  ${CMAKE_CURRENT_SOURCE_DIR}/../../src)
+set(UNITY_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../unity)
+
+option(NUMX_FORCE_32BIT "Compile as 32-bit x86 (requires multilib)" OFF)
+if(NUMX_FORCE_32BIT)
+    if(MSVC)
+        message(STATUS "NUMX_FORCE_32BIT: select the Win32 CMake generator instead.")
+    else()
+        add_compile_options(-m32)
+        add_link_options(-m32)
+    endif()
+endif()
+
+if(MSVC)
+    add_compile_options(/W3 /wd4100)
+else()
+    add_compile_options(-Wall -Wextra -Wno-unused-parameter)
+endif()
+
+# numx library — float32 (no NUMX_USE_DOUBLE)
+file(GLOB NUMX_SRCS ${NUMX_SRC}/*.c)
+add_library(numx_f32 STATIC ${NUMX_SRCS})
+target_include_directories(numx_f32 PUBLIC ${NUMX_INC})
+
+enable_testing()
+
+# ── Per-module executables ────────────────────────────────────────────────────
+# Each generates a tiny main() stub so the module can be run in isolation.
+# Build one:   cmake --build . --target numx_test_x86_linalg
+# Run one:     ./numx_test_x86_linalg          (Linux/macOS)
+#              numx_test_x86_linalg.exe         (Windows)
+# Via CTest:   ctest -R linalg
+
+function(add_numx_module_test MODULE)
+    set(STUB "${CMAKE_CURRENT_BINARY_DIR}/runner_${MODULE}.c")
+    file(WRITE ${STUB}
+        "#include \"unity.h\"\n"
+        "void numx_test_${MODULE}(void);\n"
+        "void setUp(void){}\n"
+        "void tearDown(void){}\n"
+        "int main(void){UNITY_BEGIN();numx_test_${MODULE}();return UNITY_END();}\n"
+    )
+    add_executable(numx_test_x86_${MODULE}
+        ${UNITY_DIR}/unity.c
+        test_${MODULE}.c
+        ${STUB}
+    )
+    target_include_directories(numx_test_x86_${MODULE} PRIVATE ${NUMX_INC} ${UNITY_DIR})
+    if(UNIX)
+        target_link_libraries(numx_test_x86_${MODULE} numx_f32 m)
+    else()
+        target_link_libraries(numx_test_x86_${MODULE} numx_f32)
+    endif()
+    add_test(NAME numx_x86_${MODULE} COMMAND numx_test_x86_${MODULE})
+endfunction()
+
+set(NUMX_MODULES
+    linalg stats roots integrate differentiate
+    interpolate poly ode signal fft
+    autodiff compressed_sensing sketch
+)
+foreach(MOD ${NUMX_MODULES})
+    add_numx_module_test(${MOD})
+endforeach()
+
+# ── Full suite (all modules in one run) ──────────────────────────────────────
+add_executable(numx_test_x86
+    ${UNITY_DIR}/unity.c
+    test_runner.c
+    test_linalg.c
+    test_stats.c
+    test_roots.c
+    test_integrate.c
+    test_differentiate.c
+    test_interpolate.c
+    test_poly.c
+    test_ode.c
+    test_signal.c
+    test_fft.c
+    test_autodiff.c
+    test_compressed_sensing.c
+    test_sketch.c
+)
+target_include_directories(numx_test_x86 PRIVATE ${NUMX_INC} ${UNITY_DIR})
+if(UNIX)
+    target_link_libraries(numx_test_x86 numx_f32 m)
+else()
+    target_link_libraries(numx_test_x86 numx_f32)
+endif()
+add_test(NAME numx_x86 COMMAND numx_test_x86)
+
+# ── Windows performance benchmark (float32) ──────────────────────────────────
+add_executable(numx_bench_x86
+    ${CMAKE_CURRENT_SOURCE_DIR}/../bench_win.c
+)
+target_include_directories(numx_bench_x86 PRIVATE ${NUMX_INC})
+if(UNIX)
+    target_link_libraries(numx_bench_x86 numx_f32 m)
+else()
+    target_link_libraries(numx_bench_x86 numx_f32)
+endif()

--- a/tests/x86/test_autodiff.c
+++ b/tests/x86/test_autodiff.c
@@ -1,0 +1,286 @@
+/**
+ * @file test_autodiff.c
+ * @brief Autodiff tests — float32 / x86 host build.
+ *        numx_real_t = float  (NUMX_USE_DOUBLE not set)
+ */
+
+#include "unity.h"
+#include "numx/autodiff.h"
+
+#define TOL       1e-3f
+#define TOL_TIGHT 1e-5f
+
+/* ── Forward-mode ───────────────────────────────────────────────────── */
+
+void test_dual_const(void)
+{
+    numx_dual_t c = numx_dual_const(5.0f);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 5.0f, c.re);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 0.0f, c.du);
+}
+
+void test_dual_var(void)
+{
+    numx_dual_t v = numx_dual_var(3.0f);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 3.0f, v.re);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 1.0f, v.du);
+}
+
+void test_dual_add(void)
+{
+    numx_dual_t r = numx_dual_add(numx_dual_var(2.0f), numx_dual_const(3.0f));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 5.0f, r.re);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 1.0f, r.du);
+}
+
+void test_dual_sub(void)
+{
+    numx_dual_t r = numx_dual_sub(numx_dual_var(5.0f), numx_dual_const(3.0f));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 2.0f, r.re);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 1.0f, r.du);
+}
+
+void test_dual_mul(void)
+{
+    numx_dual_t a = numx_dual_var(3.0f);
+    numx_dual_t r = numx_dual_mul(a, a);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 9.0f, r.re);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 6.0f, r.du);
+}
+
+void test_dual_div(void)
+{
+    numx_dual_t r = numx_dual_div(numx_dual_var(6.0f), numx_dual_const(3.0f));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 2.0f,        r.re);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 1.0f/3.0f,   r.du);
+}
+
+void test_dual_neg(void)
+{
+    numx_dual_t r = numx_dual_neg(numx_dual_var(3.0f));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, -3.0f, r.re);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, -1.0f, r.du);
+}
+
+void test_dual_sin(void)
+{
+    numx_dual_t r = numx_dual_sin(numx_dual_var(0.0f));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 0.0f, r.re);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 1.0f, r.du);
+}
+
+void test_dual_cos(void)
+{
+    numx_dual_t r = numx_dual_cos(numx_dual_var(0.0f));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 1.0f, r.re);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 0.0f, r.du);
+}
+
+void test_dual_exp(void)
+{
+    numx_dual_t r = numx_dual_exp(numx_dual_var(0.0f));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 1.0f, r.re);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 1.0f, r.du);
+}
+
+void test_dual_log(void)
+{
+    numx_dual_t r = numx_dual_log(numx_dual_var(1.0f));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 0.0f, r.re);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 1.0f, r.du);
+}
+
+void test_dual_sqrt(void)
+{
+    numx_dual_t r = numx_dual_sqrt(numx_dual_var(4.0f));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 2.0f,  r.re);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 0.25f, r.du);
+}
+
+void test_dual_chain_quadratic(void)
+{
+    numx_dual_t x  = numx_dual_var(3.0f);
+    numx_dual_t r  = numx_dual_add(numx_dual_mul(x, x), numx_dual_const(5.0f));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 14.0f, r.re);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT,  6.0f, r.du);
+}
+
+void test_dual_div_by_zero(void)
+{
+    numx_dual_t r = numx_dual_div(numx_dual_var(1.0f), numx_dual_const(0.0f));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 0.0f, r.re);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 0.0f, r.du);
+}
+
+void test_dual_log_nonpositive(void)
+{
+    numx_dual_t r = numx_dual_log(numx_dual_var(0.0f));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 0.0f, r.re);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 0.0f, r.du);
+}
+
+void test_dual_sqrt_negative(void)
+{
+    numx_dual_t r = numx_dual_sqrt(numx_dual_var(-4.0f));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 0.0f, r.re);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 0.0f, r.du);
+}
+
+/* ── Reverse-mode ───────────────────────────────────────────────────── */
+
+void test_ad_init(void)
+{
+    numx_ad_tape_t tape;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_ad_init(&tape));
+    TEST_ASSERT_EQUAL_UINT32(0, tape.len);
+}
+
+void test_ad_var(void)
+{
+    numx_ad_tape_t tape; numx_size_t ix;
+    numx_ad_init(&tape);
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_ad_var(&tape, 5.0f, &ix));
+    TEST_ASSERT_EQUAL_UINT32(0, ix);
+    TEST_ASSERT_EQUAL_UINT32(1, tape.len);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 5.0f, numx_ad_val(&tape, ix));
+}
+
+void test_ad_add_backward(void)
+{
+    numx_ad_tape_t tape; numx_size_t xi, yi, zi;
+    numx_ad_init(&tape);
+    numx_ad_var(&tape, 3.0f, &xi);
+    numx_ad_var(&tape, 4.0f, &yi);
+    numx_ad_add(&tape, xi, yi, &zi);
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_ad_backward(&tape, zi));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 7.0f, numx_ad_val(&tape, zi));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 1.0f, numx_ad_grad(&tape, xi));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 1.0f, numx_ad_grad(&tape, yi));
+}
+
+void test_ad_mul_backward(void)
+{
+    numx_ad_tape_t tape; numx_size_t xi, yi, zi;
+    numx_ad_init(&tape);
+    numx_ad_var(&tape, 3.0f, &xi);
+    numx_ad_var(&tape, 4.0f, &yi);
+    numx_ad_mul(&tape, xi, yi, &zi);
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_ad_backward(&tape, zi));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 12.0f, numx_ad_val(&tape, zi));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT,  4.0f, numx_ad_grad(&tape, xi));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT,  3.0f, numx_ad_grad(&tape, yi));
+}
+
+void test_ad_div_backward(void)
+{
+    numx_ad_tape_t tape; numx_size_t xi, yi, zi;
+    numx_ad_init(&tape);
+    numx_ad_var(&tape, 6.0f, &xi);
+    numx_ad_var(&tape, 2.0f, &yi);
+    numx_ad_div(&tape, xi, yi, &zi);
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_ad_backward(&tape, zi));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT,  0.5f, numx_ad_grad(&tape, xi));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, -1.5f, numx_ad_grad(&tape, yi));
+}
+
+void test_ad_sin_backward(void)
+{
+    numx_ad_tape_t tape; numx_size_t xi, zi;
+    numx_ad_init(&tape);
+    numx_ad_var(&tape, 0.0f, &xi);
+    numx_ad_sin(&tape, xi, &zi);
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_ad_backward(&tape, zi));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 1.0f, numx_ad_grad(&tape, xi));
+}
+
+void test_ad_quadratic(void)
+{
+    numx_ad_tape_t tape; numx_size_t xi, yi, x2i, y2i, zi;
+    numx_ad_init(&tape);
+    numx_ad_var(&tape, 3.0f, &xi);
+    numx_ad_var(&tape, 4.0f, &yi);
+    numx_ad_mul(&tape, xi, xi, &x2i);
+    numx_ad_mul(&tape, yi, yi, &y2i);
+    numx_ad_add(&tape, x2i, y2i, &zi);
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_ad_backward(&tape, zi));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 25.0f, numx_ad_val(&tape, zi));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT,  6.0f, numx_ad_grad(&tape, xi));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT,  8.0f, numx_ad_grad(&tape, yi));
+}
+
+void test_ad_null_returns_error(void)
+{
+    numx_ad_tape_t tape; numx_size_t ix;
+    numx_ad_init(&tape);
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_ad_init(NULL));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_ad_var(NULL, 1.0f, &ix));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_ad_var(&tape, 1.0f, NULL));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_ad_backward(NULL, 0));
+}
+
+void test_ad_invalid_idx_returns_error(void)
+{
+    numx_ad_tape_t tape; numx_size_t xi, zi;
+    numx_ad_init(&tape);
+    numx_ad_var(&tape, 1.0f, &xi);
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_ad_backward(&tape, 999));
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_ad_add(&tape, 0, 999, &zi));
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_ad_neg(&tape, 999, &zi));
+}
+
+void test_ad_div_by_zero_returns_error(void)
+{
+    numx_ad_tape_t tape; numx_size_t xi, yi, zi;
+    numx_ad_init(&tape);
+    numx_ad_var(&tape, 6.0f, &xi);
+    numx_ad_var(&tape, 0.0f, &yi);
+    TEST_ASSERT_EQUAL(NUMX_ERR_SINGULAR, numx_ad_div(&tape, xi, yi, &zi));
+}
+
+void test_ad_log_nonpositive_returns_error(void)
+{
+    numx_ad_tape_t tape; numx_size_t xi, zi;
+    numx_ad_init(&tape);
+    numx_ad_var(&tape, 0.0f, &xi);
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_ad_log(&tape, xi, &zi));
+}
+
+void test_ad_sqrt_negative_returns_error(void)
+{
+    numx_ad_tape_t tape; numx_size_t xi, zi;
+    numx_ad_init(&tape);
+    numx_ad_var(&tape, -1.0f, &xi);
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_ad_sqrt(&tape, xi, &zi));
+}
+
+void numx_test_autodiff(void)
+{
+    RUN_TEST(test_dual_const);
+    RUN_TEST(test_dual_var);
+    RUN_TEST(test_dual_add);
+    RUN_TEST(test_dual_sub);
+    RUN_TEST(test_dual_mul);
+    RUN_TEST(test_dual_div);
+    RUN_TEST(test_dual_neg);
+    RUN_TEST(test_dual_sin);
+    RUN_TEST(test_dual_cos);
+    RUN_TEST(test_dual_exp);
+    RUN_TEST(test_dual_log);
+    RUN_TEST(test_dual_sqrt);
+    RUN_TEST(test_dual_chain_quadratic);
+    RUN_TEST(test_dual_div_by_zero);
+    RUN_TEST(test_dual_log_nonpositive);
+    RUN_TEST(test_dual_sqrt_negative);
+    RUN_TEST(test_ad_init);
+    RUN_TEST(test_ad_var);
+    RUN_TEST(test_ad_add_backward);
+    RUN_TEST(test_ad_mul_backward);
+    RUN_TEST(test_ad_div_backward);
+    RUN_TEST(test_ad_sin_backward);
+    RUN_TEST(test_ad_quadratic);
+    RUN_TEST(test_ad_null_returns_error);
+    RUN_TEST(test_ad_invalid_idx_returns_error);
+    RUN_TEST(test_ad_div_by_zero_returns_error);
+    RUN_TEST(test_ad_log_nonpositive_returns_error);
+    RUN_TEST(test_ad_sqrt_negative_returns_error);
+}

--- a/tests/x86/test_compressed_sensing.c
+++ b/tests/x86/test_compressed_sensing.c
@@ -1,0 +1,176 @@
+/**
+ * @file test_compressed_sensing.c
+ * @brief Compressed sensing tests — float32 / x86 host build.
+ *        numx_real_t = float  (NUMX_USE_DOUBLE not set)
+ */
+
+#include "unity.h"
+#include "numx/compressed_sensing.h"
+
+#define TOL       1e-3f
+#define TOL_TIGHT 1e-4f
+
+void test_omp_identity_1sparse(void)
+{
+    numx_real_t A[16] = {1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1};
+    numx_real_t y[4]  = {1.0f,0.0f,0.0f,0.0f};
+    numx_real_t x[4]  = {0};
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_cs_omp(A, y, 4, 4, 1, x));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 1.0f, x[0]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 0.0f, x[1]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 0.0f, x[2]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 0.0f, x[3]);
+}
+
+void test_omp_identity_2sparse(void)
+{
+    numx_real_t A[16] = {1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1};
+    numx_real_t y[4]  = {0.0f,1.0f,0.0f,1.0f};
+    numx_real_t x[4]  = {0};
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_cs_omp(A, y, 4, 4, 2, x));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 0.0f, x[0]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 1.0f, x[1]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 0.0f, x[2]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 1.0f, x[3]);
+}
+
+void test_omp_overdetermined_1sparse(void)
+{
+    numx_real_t A[6] = {1,0, 0,1, 1,1};
+    numx_real_t y[3] = {2.0f,0.0f,2.0f};
+    numx_real_t x[2] = {0};
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_cs_omp(A, y, 3, 2, 1, x));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 2.0f, x[0]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 0.0f, x[1]);
+}
+
+void test_omp_null_returns_error(void)
+{
+    numx_real_t A[4]={0},y[2]={0},x[2]={0};
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_cs_omp(NULL,y,2,2,1,x));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_cs_omp(A,NULL,2,2,1,x));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_cs_omp(A,y,2,2,1,NULL));
+}
+
+void test_omp_invalid_arg_returns_error(void)
+{
+    numx_real_t A[4]={0},y[2]={0},x[2]={0};
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_cs_omp(A,y,2,2,3,x));
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_cs_omp(A,y,0,2,1,x));
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_cs_omp(A,y,2,2,0,x));
+}
+
+void test_ista_identity_shrinkage(void)
+{
+    numx_real_t A[16] = {1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1};
+    numx_real_t y[4]  = {1.0f,0.0f,0.0f,0.0f};
+    numx_real_t x[4]  = {0};
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_cs_ista(A, y, 4, 4, 0.1f, 1.0f, 10, x));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 0.9f, x[0]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 0.0f, x[1]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 0.0f, x[2]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 0.0f, x[3]);
+}
+
+void test_ista_zero_lambda_recovery(void)
+{
+    numx_real_t A[16] = {1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1};
+    numx_real_t y[4]  = {1.0f,0.0f,0.0f,0.0f};
+    numx_real_t x[4]  = {0};
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_cs_ista(A, y, 4, 4, 0.0f, 0.9f, 100, x));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 1.0f, x[0]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 0.0f, x[1]);
+}
+
+void test_ista_large_lambda_zeros(void)
+{
+    numx_real_t A[16] = {1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1};
+    numx_real_t y[4]  = {1.0f,0.0f,0.0f,0.0f};
+    numx_real_t x[4]  = {0};
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_cs_ista(A, y, 4, 4, 2.0f, 1.0f, 20, x));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 0.0f, x[0]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 0.0f, x[1]);
+}
+
+void test_ista_null_returns_error(void)
+{
+    numx_real_t A[4]={0},y[2]={0},x[2]={0};
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_cs_ista(NULL,y,2,2,0.1f,1.0f,10,x));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_cs_ista(A,NULL,2,2,0.1f,1.0f,10,x));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_cs_ista(A,y,2,2,0.1f,1.0f,10,NULL));
+}
+
+void test_ista_invalid_step_returns_error(void)
+{
+    numx_real_t A[4]={0},y[2]={0},x[2]={0};
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_cs_ista(A,y,2,2,0.1f,0.0f,10,x));
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_cs_ista(A,y,2,2,-0.1f,1.0f,10,x));
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_cs_ista(A,y,0,2,0.1f,1.0f,10,x));
+}
+
+void test_spectral_norm_identity(void)
+{
+    numx_real_t A[16] = {1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1};
+    numx_real_t sigma;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_cs_spectral_norm(A, 4, 4, 32, &sigma));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 1.0f, sigma);
+}
+
+void test_spectral_norm_scaled_identity(void)
+{
+    numx_real_t A[16] = {3,0,0,0, 0,3,0,0, 0,0,3,0, 0,0,0,3};
+    numx_real_t sigma;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_cs_spectral_norm(A, 4, 4, 32, &sigma));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 3.0f, sigma);
+}
+
+void test_spectral_norm_tall_matrix(void)
+{
+    numx_real_t A[6] = {1,0, 0,1, 0,0};
+    numx_real_t sigma;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_cs_spectral_norm(A, 3, 2, 32, &sigma));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 1.0f, sigma);
+}
+
+void test_spectral_norm_null_returns_error(void)
+{
+    numx_real_t A[4]={0},sigma;
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_cs_spectral_norm(NULL,2,2,32,&sigma));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_cs_spectral_norm(A,2,2,32,NULL));
+}
+
+void test_spectral_norm_invalid_arg(void)
+{
+    numx_real_t A[4]={0},sigma;
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_cs_spectral_norm(A,0,2,32,&sigma));
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_cs_spectral_norm(A,2,0,32,&sigma));
+}
+
+void numx_test_compressed_sensing(void)
+{
+    RUN_TEST(test_omp_identity_1sparse);
+    RUN_TEST(test_omp_identity_2sparse);
+    RUN_TEST(test_omp_overdetermined_1sparse);
+    RUN_TEST(test_omp_null_returns_error);
+    RUN_TEST(test_omp_invalid_arg_returns_error);
+    RUN_TEST(test_ista_identity_shrinkage);
+    RUN_TEST(test_ista_zero_lambda_recovery);
+    RUN_TEST(test_ista_large_lambda_zeros);
+    RUN_TEST(test_ista_null_returns_error);
+    RUN_TEST(test_ista_invalid_step_returns_error);
+    RUN_TEST(test_spectral_norm_identity);
+    RUN_TEST(test_spectral_norm_scaled_identity);
+    RUN_TEST(test_spectral_norm_tall_matrix);
+    RUN_TEST(test_spectral_norm_null_returns_error);
+    RUN_TEST(test_spectral_norm_invalid_arg);
+}

--- a/tests/x86/test_differentiate.c
+++ b/tests/x86/test_differentiate.c
@@ -1,0 +1,184 @@
+/**
+ * @file test_differentiate.c
+ * @brief Differentiation tests — float32 / x86 host build.
+ *        numx_real_t = float  (NUMX_USE_DOUBLE not set)
+ *
+ * float32 round-off dominates at small h; tolerances are loose.
+ */
+
+#include "unity.h"
+#include "numx/numx_types.h"
+#include "numx/differentiate.h"
+
+#define TOL_FWD  1e-2f
+#define TOL_CTR  1e-3f
+#define TOL_RICH 1e-3f
+
+static const numx_real_t H = 1e-3f;
+
+static numx_real_t f_quad(numx_real_t x)  { return x*x; }
+static numx_real_t f_cubic(numx_real_t x) { return x*x*x; }
+static numx_real_t f_const(numx_real_t x) { (void)x; return (numx_real_t)1.0; }
+static numx_real_t f_linear(numx_real_t x){ return x; }
+
+void test_fwd_quadratic_at_3(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_diff_forward(f_quad, 3.0f, H, &r));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_FWD, 6.0f, r);
+}
+
+void test_fwd_cubic_at_2(void)
+{
+    numx_real_t r;
+    numx_diff_forward(f_cubic, 2.0f, H, &r);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_FWD, 12.0f, r);
+}
+
+void test_fwd_constant_is_zero(void)
+{
+    numx_real_t r;
+    numx_diff_forward(f_const, 5.0f, H, &r);
+    TEST_ASSERT_FLOAT_WITHIN(1e-6f, 0.0f, r);
+}
+
+void test_fwd_linear_is_one(void)
+{
+    numx_real_t r;
+    numx_diff_forward(f_linear, 5.0f, H, &r);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_FWD, 1.0f, r);
+}
+
+void test_fwd_null(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_diff_forward(NULL, 1.0f, H, &r));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_diff_forward(f_quad, 1.0f, H, NULL));
+}
+
+void test_fwd_nonpositive_h(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_diff_forward(f_quad, 1.0f, 0.0f, &r));
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_diff_forward(f_quad, 1.0f, -1.0f, &r));
+}
+
+void test_central_quadratic_at_3(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_diff_central(f_quad, 3.0f, H, &r));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_CTR, 6.0f, r);
+}
+
+void test_central_quadratic_at_neg2(void)
+{
+    numx_real_t r;
+    numx_diff_central(f_quad, -2.0f, H, &r);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_CTR, -4.0f, r);
+}
+
+void test_central_cubic_at_2(void)
+{
+    numx_real_t r;
+    numx_diff_central(f_cubic, 2.0f, H, &r);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_CTR, 12.0f, r);
+}
+
+void test_central_constant_is_zero(void)
+{
+    numx_real_t r;
+    numx_diff_central(f_const, 5.0f, H, &r);
+    TEST_ASSERT_FLOAT_WITHIN(1e-6f, 0.0f, r);
+}
+
+void test_central_linear_exact(void)
+{
+    numx_real_t r;
+    numx_diff_central(f_linear, 1.0f, H, &r);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_CTR, 1.0f, r);
+}
+
+void test_central_null(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_diff_central(NULL, 1.0f, H, &r));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_diff_central(f_quad, 1.0f, H, NULL));
+}
+
+void test_central_nonpositive_h(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_diff_central(f_quad, 1.0f, 0.0f, &r));
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_diff_central(f_quad, 1.0f, -1e-3f, &r));
+}
+
+void test_richardson_quadratic_at_3(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_diff_richardson(f_quad, 3.0f, H, &r));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_RICH, 6.0f, r);
+}
+
+void test_richardson_cubic_at_2(void)
+{
+    numx_real_t r;
+    numx_diff_richardson(f_cubic, 2.0f, H, &r);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_RICH, 12.0f, r);
+}
+
+void test_richardson_more_accurate_than_central(void)
+{
+    numx_real_t rc, rr;
+    numx_real_t h_large = 0.1f;
+    numx_diff_central(f_cubic, 2.0f, h_large, &rc);
+    numx_diff_richardson(f_cubic, 2.0f, h_large, &rr);
+    numx_real_t err_c = rc - 12.0f;
+    if (err_c < 0.0f) err_c = -err_c;
+    numx_real_t err_r = rr - 12.0f;
+    if (err_r < 0.0f) err_r = -err_r;
+    TEST_ASSERT_TRUE(err_r < err_c);
+}
+
+void test_richardson_constant_is_zero(void)
+{
+    numx_real_t r;
+    numx_diff_richardson(f_const, 5.0f, H, &r);
+    TEST_ASSERT_FLOAT_WITHIN(1e-6f, 0.0f, r);
+}
+
+void test_richardson_null(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_diff_richardson(NULL, 1.0f, H, &r));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_diff_richardson(f_quad, 1.0f, H, NULL));
+}
+
+void test_richardson_nonpositive_h(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_diff_richardson(f_quad, 1.0f, 0.0f, &r));
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_diff_richardson(f_quad, 1.0f, -1e-3f, &r));
+}
+
+void numx_test_differentiate(void)
+{
+    RUN_TEST(test_fwd_quadratic_at_3);
+    RUN_TEST(test_fwd_cubic_at_2);
+    RUN_TEST(test_fwd_constant_is_zero);
+    RUN_TEST(test_fwd_linear_is_one);
+    RUN_TEST(test_fwd_null);
+    RUN_TEST(test_fwd_nonpositive_h);
+    RUN_TEST(test_central_quadratic_at_3);
+    RUN_TEST(test_central_quadratic_at_neg2);
+    RUN_TEST(test_central_cubic_at_2);
+    RUN_TEST(test_central_constant_is_zero);
+    RUN_TEST(test_central_linear_exact);
+    RUN_TEST(test_central_null);
+    RUN_TEST(test_central_nonpositive_h);
+    RUN_TEST(test_richardson_quadratic_at_3);
+    RUN_TEST(test_richardson_cubic_at_2);
+    RUN_TEST(test_richardson_more_accurate_than_central);
+    RUN_TEST(test_richardson_constant_is_zero);
+    RUN_TEST(test_richardson_null);
+    RUN_TEST(test_richardson_nonpositive_h);
+}

--- a/tests/x86/test_fft.c
+++ b/tests/x86/test_fft.c
@@ -1,0 +1,182 @@
+/**
+ * @file test_fft.c
+ * @brief FFT tests — float32 / x86 host build.
+ *        numx_real_t = float  (NUMX_USE_DOUBLE not set)
+ *
+ * Twiddle-factor tolerance is loose (1e-3f): priv_cos/sin uses
+ * a Taylor approximation rather than a hardware FPU instruction.
+ */
+
+#include "unity.h"
+#include "numx/fft.h"
+
+#define TOL       1e-3f
+#define TOL_TIGHT 1e-4f
+
+void test_fft_dc_n4(void)
+{
+    numx_real_t x[] = {1.0f,0.0f, 1.0f,0.0f, 1.0f,0.0f, 1.0f,0.0f};
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_fft_f32(x, 4));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 4.0f, x[0]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 0.0f, x[1]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 0.0f, x[2]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 0.0f, x[4]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 0.0f, x[6]);
+}
+
+void test_fft_single_tone_n4(void)
+{
+    numx_real_t x[] = {1.0f,0.0f, 0.0f,1.0f, -1.0f,0.0f, 0.0f,-1.0f};
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_fft_f32(x, 4));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 0.0f, x[0]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 4.0f, x[2]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 0.0f, x[3]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 0.0f, x[4]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 0.0f, x[6]);
+}
+
+void test_fft_dc_n2(void)
+{
+    numx_real_t x[] = {1.0f,0.0f, 1.0f,0.0f};
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_fft_f32(x, 2));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 2.0f, x[0]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 0.0f, x[1]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 0.0f, x[2]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 0.0f, x[3]);
+}
+
+void test_fft_n1_passthrough(void)
+{
+    numx_real_t x[] = {3.5f, -1.2f};
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_fft_f32(x, 1));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT,  3.5f, x[0]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, -1.2f, x[1]);
+}
+
+void test_fft_delta_at_0(void)
+{
+    numx_real_t x[] = {4.0f,0.0f, 0.0f,0.0f, 0.0f,0.0f, 0.0f,0.0f};
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_fft_f32(x, 4));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 4.0f, x[0]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 4.0f, x[2]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 4.0f, x[4]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 4.0f, x[6]);
+}
+
+void test_fft_null_returns_error(void)
+{
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_fft_f32(NULL, 4));
+}
+
+void test_fft_n_not_power_of_two(void)
+{
+    numx_real_t x[6] = {0};
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_fft_f32(x, 3));
+}
+
+void test_fft_n_exceeds_max(void)
+{
+    numx_real_t x[2] = {0};
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_fft_f32(x, NUMX_MAX_FFT_SIZE*2));
+}
+
+void test_ifft_roundtrip(void)
+{
+    numx_real_t orig[] = {1.0f,0.0f, 2.0f,0.0f, 3.0f,0.0f, 0.0f,0.0f};
+    numx_real_t x[]    = {1.0f,0.0f, 2.0f,0.0f, 3.0f,0.0f, 0.0f,0.0f};
+    numx_size_t i;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_fft_f32(x, 4));
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_ifft_f32(x, 4));
+    for (i = 0; i < 8; i++) TEST_ASSERT_FLOAT_WITHIN(TOL, orig[i], x[i]);
+}
+
+void test_ifft_dc_spectrum(void)
+{
+    numx_real_t x[] = {4.0f,0.0f, 0.0f,0.0f, 0.0f,0.0f, 0.0f,0.0f};
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_ifft_f32(x, 4));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 1.0f, x[0]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 0.0f, x[1]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 1.0f, x[2]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 1.0f, x[4]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 1.0f, x[6]);
+}
+
+void test_ifft_null_returns_error(void)
+{
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_ifft_f32(NULL, 4));
+}
+
+void test_fft_q15_dc_n4(void)
+{
+    numx_q15_t x[] = {0x4000,0, 0x4000,0, 0x4000,0, 0x4000,0};
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_fft_q15(x, 4));
+    TEST_ASSERT_INT16_WITHIN(2, 0x4000, x[0]);
+    TEST_ASSERT_INT16_WITHIN(2, 0,      x[1]);
+    TEST_ASSERT_INT16_WITHIN(2, 0, x[2]);
+    TEST_ASSERT_INT16_WITHIN(2, 0, x[4]);
+    TEST_ASSERT_INT16_WITHIN(2, 0, x[6]);
+}
+
+void test_fft_q15_null_returns_error(void)
+{
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_fft_q15(NULL, 4));
+}
+
+void test_fft_q15_n_not_power_of_two(void)
+{
+    numx_q15_t x[6] = {0};
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_fft_q15(x, 3));
+}
+
+void test_fft_magnitude_dc(void)
+{
+    numx_real_t fft_out[] = {4.0f,0.0f, 0.0f,0.0f, 0.0f,0.0f, 0.0f,0.0f};
+    numx_real_t mag[3];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_fft_magnitude(fft_out, 4, mag));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 4.0f, mag[0]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 0.0f, mag[1]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TIGHT, 0.0f, mag[2]);
+}
+
+void test_fft_magnitude_complex_bin(void)
+{
+    numx_real_t fft_out[] = {3.0f,4.0f, 0.0f,0.0f, 0.0f,0.0f};
+    numx_real_t mag[2];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_fft_magnitude(fft_out, 2, mag));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 5.0f, mag[0]);
+}
+
+void test_fft_magnitude_null_returns_error(void)
+{
+    numx_real_t fft_out[4]={0}, mag[3]={0};
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_fft_magnitude(NULL, 4, mag));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_fft_magnitude(fft_out, 4, NULL));
+}
+
+void test_fft_magnitude_n1_invalid(void)
+{
+    numx_real_t fft_out[2]={0}, mag[1]={0};
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_fft_magnitude(fft_out, 1, mag));
+}
+
+void numx_test_fft(void)
+{
+    RUN_TEST(test_fft_dc_n4);
+    RUN_TEST(test_fft_single_tone_n4);
+    RUN_TEST(test_fft_dc_n2);
+    RUN_TEST(test_fft_n1_passthrough);
+    RUN_TEST(test_fft_delta_at_0);
+    RUN_TEST(test_fft_null_returns_error);
+    RUN_TEST(test_fft_n_not_power_of_two);
+    RUN_TEST(test_fft_n_exceeds_max);
+    RUN_TEST(test_ifft_roundtrip);
+    RUN_TEST(test_ifft_dc_spectrum);
+    RUN_TEST(test_ifft_null_returns_error);
+    RUN_TEST(test_fft_q15_dc_n4);
+    RUN_TEST(test_fft_q15_null_returns_error);
+    RUN_TEST(test_fft_q15_n_not_power_of_two);
+    RUN_TEST(test_fft_magnitude_dc);
+    RUN_TEST(test_fft_magnitude_complex_bin);
+    RUN_TEST(test_fft_magnitude_null_returns_error);
+    RUN_TEST(test_fft_magnitude_n1_invalid);
+}

--- a/tests/x86/test_integrate.c
+++ b/tests/x86/test_integrate.c
@@ -1,0 +1,213 @@
+/**
+ * @file test_integrate.c
+ * @brief Integration tests — float32 / x86 host build.
+ *        numx_real_t = float  (NUMX_USE_DOUBLE not set)
+ */
+
+#include "unity.h"
+#include "numx/numx_types.h"
+#include "numx/integrate.h"
+
+#define TOL_TRAP  1e-3f
+#define TOL_SIMP  1e-5f
+#define TOL_GAUSS 1e-5f
+
+static numx_real_t f_one(numx_real_t x)   { (void)x; return (numx_real_t)1.0; }
+static numx_real_t f_linear(numx_real_t x){ return x; }
+static numx_real_t f_quad(numx_real_t x)  { return x*x; }
+static numx_real_t f_cubic(numx_real_t x) { return x*x*x; }
+static numx_real_t f_neg(numx_real_t x)   { return -x; }
+
+void test_trap_constant_one(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_integrate_trap(f_one, 0.0f, 1.0f, 100, &r));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TRAP, 1.0f, r);
+}
+
+void test_trap_linear(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_integrate_trap(f_linear, 0.0f, 1.0f, 100, &r));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TRAP, 0.5f, r);
+}
+
+void test_trap_quadratic(void)
+{
+    numx_real_t r;
+    numx_integrate_trap(f_quad, 0.0f, 1.0f, 1000, &r);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TRAP, 1.0f/3.0f, r);
+}
+
+void test_trap_linearity(void)
+{
+    numx_real_t r1, r2;
+    numx_integrate_trap(f_linear, 0.0f, 2.0f, 100, &r1);
+    numx_integrate_trap(f_neg, 0.0f, 2.0f, 100, &r2);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TRAP, r1, -r2);
+}
+
+void test_trap_n1(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_integrate_trap(f_one, 0.0f, 1.0f, 1, &r));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_TRAP, 1.0f, r);
+}
+
+void test_trap_null(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_integrate_trap(NULL, 0.0f, 1.0f, 10, &r));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_integrate_trap(f_one, 0.0f, 1.0f, 10, NULL));
+}
+
+void test_trap_a_ge_b(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_integrate_trap(f_one, 1.0f, 0.0f, 10, &r));
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_integrate_trap(f_one, 1.0f, 1.0f, 10, &r));
+}
+
+void test_trap_n_zero(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_integrate_trap(f_one, 0.0f, 1.0f, 0, &r));
+}
+
+void test_simpson_constant_one(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_integrate_simpson(f_one, 0.0f, 1.0f, 2, &r));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_SIMP, 1.0f, r);
+}
+
+void test_simpson_linear_exact(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_integrate_simpson(f_linear, 0.0f, 1.0f, 2, &r));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_SIMP, 0.5f, r);
+}
+
+void test_simpson_quadratic_exact(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_integrate_simpson(f_quad, 0.0f, 1.0f, 4, &r));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_SIMP, 1.0f/3.0f, r);
+}
+
+void test_simpson_cubic_exact(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_integrate_simpson(f_cubic, 0.0f, 1.0f, 4, &r));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_SIMP, 0.25f, r);
+}
+
+void test_simpson_wider_interval(void)
+{
+    numx_real_t r;
+    numx_integrate_simpson(f_quad, 0.0f, 3.0f, 6, &r);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_SIMP, 9.0f, r);
+}
+
+void test_simpson_odd_n_rejected(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_integrate_simpson(f_one, 0.0f, 1.0f, 3, &r));
+}
+
+void test_simpson_n_lt_2_rejected(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_integrate_simpson(f_one, 0.0f, 1.0f, 0, &r));
+}
+
+void test_simpson_null(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_integrate_simpson(NULL, 0.0f, 1.0f, 4, &r));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_integrate_simpson(f_one, 0.0f, 1.0f, 4, NULL));
+}
+
+void test_gauss2_linear(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_integrate_gauss(f_linear, 0.0f, 1.0f, 2, &r));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_GAUSS, 0.5f, r);
+}
+
+void test_gauss4_quadratic_exact(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_integrate_gauss(f_quad, 0.0f, 1.0f, 4, &r));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_GAUSS, 1.0f/3.0f, r);
+}
+
+void test_gauss8_cubic_exact(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_integrate_gauss(f_cubic, 0.0f, 1.0f, 8, &r));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_GAUSS, 0.25f, r);
+}
+
+void test_gauss8_constant_exact(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_integrate_gauss(f_one, -3.0f, 3.0f, 8, &r));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_GAUSS, 6.0f, r);
+}
+
+void test_gauss_null(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_integrate_gauss(NULL, 0.0f, 1.0f, 4, &r));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_integrate_gauss(f_one, 0.0f, 1.0f, 4, NULL));
+}
+
+void test_gauss_invalid_npts(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_integrate_gauss(f_one, 0.0f, 1.0f, 3, &r));
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_integrate_gauss(f_one, 0.0f, 1.0f, 16, &r));
+}
+
+void test_gauss_a_ge_b(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_integrate_gauss(f_one, 1.0f, 0.0f, 4, &r));
+}
+
+void numx_test_integrate(void)
+{
+    RUN_TEST(test_trap_constant_one);
+    RUN_TEST(test_trap_linear);
+    RUN_TEST(test_trap_quadratic);
+    RUN_TEST(test_trap_linearity);
+    RUN_TEST(test_trap_n1);
+    RUN_TEST(test_trap_null);
+    RUN_TEST(test_trap_a_ge_b);
+    RUN_TEST(test_trap_n_zero);
+    RUN_TEST(test_simpson_constant_one);
+    RUN_TEST(test_simpson_linear_exact);
+    RUN_TEST(test_simpson_quadratic_exact);
+    RUN_TEST(test_simpson_cubic_exact);
+    RUN_TEST(test_simpson_wider_interval);
+    RUN_TEST(test_simpson_odd_n_rejected);
+    RUN_TEST(test_simpson_n_lt_2_rejected);
+    RUN_TEST(test_simpson_null);
+    RUN_TEST(test_gauss2_linear);
+    RUN_TEST(test_gauss4_quadratic_exact);
+    RUN_TEST(test_gauss8_cubic_exact);
+    RUN_TEST(test_gauss8_constant_exact);
+    RUN_TEST(test_gauss_null);
+    RUN_TEST(test_gauss_invalid_npts);
+    RUN_TEST(test_gauss_a_ge_b);
+}

--- a/tests/x86/test_interpolate.c
+++ b/tests/x86/test_interpolate.c
@@ -1,0 +1,247 @@
+/**
+ * @file test_interpolate.c
+ * @brief Interpolation tests — float32 / x86 host build.
+ *        numx_real_t = float  (NUMX_USE_DOUBLE not set)
+ */
+
+#include "unity.h"
+#include "numx/numx_types.h"
+#include "numx/interpolate.h"
+
+#define TOL      1e-4f
+#define TOL_CHEB 1e-4f
+
+static numx_real_t f_quad(numx_real_t x)  { return x*x; }
+static numx_real_t f_linear(numx_real_t x){ return x; }
+static numx_real_t f_const(numx_real_t x) { (void)x; return (numx_real_t)3.0; }
+
+void test_linear_midpoint_known(void)
+{
+    numx_real_t xs[] = {0.0f,1.0f,2.0f};
+    numx_real_t ys[] = {0.0f,1.0f,4.0f};
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_interp_linear(xs, ys, 3, 0.5f, &r));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 0.5f, r);
+}
+
+void test_linear_second_interval(void)
+{
+    numx_real_t xs[] = {0.0f,1.0f,2.0f};
+    numx_real_t ys[] = {0.0f,1.0f,4.0f};
+    numx_real_t r;
+    numx_interp_linear(xs, ys, 3, 1.5f, &r);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 2.5f, r);
+}
+
+void test_linear_at_knots(void)
+{
+    numx_real_t xs[] = {0.0f,1.0f,3.0f,6.0f};
+    numx_real_t ys[] = {1.0f,3.0f,2.0f,5.0f};
+    numx_real_t r; numx_size_t i;
+    for (i = 0; i < 4; i++)
+    {
+        numx_interp_linear(xs, ys, 4, xs[i], &r);
+        TEST_ASSERT_FLOAT_WITHIN(TOL, ys[i], r);
+    }
+}
+
+void test_linear_clamp_below(void)
+{
+    numx_real_t xs[] = {1.0f,2.0f,3.0f};
+    numx_real_t ys[] = {10.0f,20.0f,30.0f};
+    numx_real_t r;
+    numx_interp_linear(xs, ys, 3, 0.0f, &r);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 10.0f, r);
+}
+
+void test_linear_clamp_above(void)
+{
+    numx_real_t xs[] = {1.0f,2.0f,3.0f};
+    numx_real_t ys[] = {10.0f,20.0f,30.0f};
+    numx_real_t r;
+    numx_interp_linear(xs, ys, 3, 5.0f, &r);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 30.0f, r);
+}
+
+void test_linear_n2(void)
+{
+    numx_real_t xs[] = {0.0f,4.0f};
+    numx_real_t ys[] = {0.0f,8.0f};
+    numx_real_t r;
+    numx_interp_linear(xs, ys, 2, 2.0f, &r);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 4.0f, r);
+}
+
+void test_linear_null(void)
+{
+    numx_real_t xs[] = {0.0f,1.0f}, ys[] = {0.0f,1.0f}, r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_interp_linear(NULL, ys, 2, 0.5f, &r));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_interp_linear(xs, NULL, 2, 0.5f, &r));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_interp_linear(xs, ys, 2, 0.5f, NULL));
+}
+
+void test_linear_n_lt_2(void)
+{
+    numx_real_t xs[] = {1.0f}, ys[] = {1.0f}, r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_interp_linear(xs, ys, 1, 1.0f, &r));
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_interp_linear(xs, ys, 0, 1.0f, &r));
+}
+
+void test_spline_linear_data_exact(void)
+{
+    numx_real_t xs[] = {0.0f,1.0f,2.0f,3.0f};
+    numx_real_t ys[] = {0.0f,1.0f,2.0f,3.0f};
+    numx_real_t m[4], r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_interp_spline_precompute(xs, ys, 4, m));
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_interp_spline_eval(xs, ys, m, 4, 0.5f, &r));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 0.5f, r);
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_interp_spline_eval(xs, ys, m, 4, 1.7f, &r));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 1.7f, r);
+}
+
+void test_spline_cubic_oneshot_midpoint(void)
+{
+    numx_real_t xs[] = {0.0f,1.0f,2.0f,3.0f};
+    numx_real_t ys[] = {0.0f,1.0f,4.0f,9.0f};
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_interp_spline_cubic(xs, ys, 4, 0.5f, &r));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 0.35f, r);
+}
+
+void test_spline_at_knots(void)
+{
+    numx_real_t xs[] = {0.0f,1.0f,2.0f,3.0f,4.0f};
+    numx_real_t ys[] = {1.0f,3.0f,2.0f,5.0f,4.0f};
+    numx_real_t m[5], r; numx_size_t i;
+    numx_interp_spline_precompute(xs, ys, 5, m);
+    for (i = 0; i < 5; i++)
+    {
+        numx_interp_spline_eval(xs, ys, m, 5, xs[i], &r);
+        TEST_ASSERT_FLOAT_WITHIN(TOL, ys[i], r);
+    }
+}
+
+void test_spline_clamp_below(void)
+{
+    numx_real_t xs[] = {1.0f,2.0f,3.0f}, ys[] = {1.0f,4.0f,9.0f}, r;
+    numx_interp_spline_cubic(xs, ys, 3, 0.0f, &r);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 1.0f, r);
+}
+
+void test_spline_clamp_above(void)
+{
+    numx_real_t xs[] = {1.0f,2.0f,3.0f}, ys[] = {1.0f,4.0f,9.0f}, r;
+    numx_interp_spline_cubic(xs, ys, 3, 5.0f, &r);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 9.0f, r);
+}
+
+void test_spline_n2(void)
+{
+    numx_real_t xs[] = {0.0f,2.0f}, ys[] = {0.0f,4.0f}, r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_interp_spline_cubic(xs, ys, 2, 1.0f, &r));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 2.0f, r);
+}
+
+void test_spline_precompute_null(void)
+{
+    numx_real_t xs[] = {0.0f,1.0f}, ys[] = {0.0f,1.0f}, m[2];
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_interp_spline_precompute(NULL, ys, 2, m));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_interp_spline_precompute(xs, NULL, 2, m));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_interp_spline_precompute(xs, ys, 2, NULL));
+}
+
+void test_spline_precompute_n_lt_2(void)
+{
+    numx_real_t xs[] = {1.0f}, ys[] = {1.0f}, m[1];
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_interp_spline_precompute(xs, ys, 1, m));
+}
+
+void test_cheb_constant(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_interp_chebyshev(f_const, 4, 0.0f, 1.0f, 0.5f, &r));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_CHEB, 3.0f, r);
+}
+
+void test_cheb_linear_exact(void)
+{
+    numx_real_t r;
+    numx_interp_chebyshev(f_linear, 4, 0.0f, 2.0f, 1.0f, &r);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_CHEB, 1.0f, r);
+}
+
+void test_cheb_quadratic_exact(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_interp_chebyshev(f_quad, 4, -1.0f, 1.0f, 0.5f, &r));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_CHEB, 0.25f, r);
+}
+
+void test_cheb_quadratic_at_zero(void)
+{
+    numx_real_t r;
+    numx_interp_chebyshev(f_quad, 4, -1.0f, 1.0f, 0.0f, &r);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_CHEB, 0.0f, r);
+}
+
+void test_cheb_n2_gives_linear_interp(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_interp_chebyshev(f_quad, 2, -1.0f, 1.0f, 0.0f, &r));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_CHEB, 0.5f, r);
+}
+
+void test_cheb_null(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_interp_chebyshev(NULL, 4, 0.0f, 1.0f, 0.5f, &r));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_interp_chebyshev(f_quad, 4, 0.0f, 1.0f, 0.5f, NULL));
+}
+
+void test_cheb_b_le_a(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_interp_chebyshev(f_quad, 4, 1.0f, 0.0f, 0.5f, &r));
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_interp_chebyshev(f_quad, 4, 1.0f, 1.0f, 0.5f, &r));
+}
+
+void test_cheb_n_lt_2(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_interp_chebyshev(f_quad, 1, 0.0f, 1.0f, 0.5f, &r));
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_interp_chebyshev(f_quad, 0, 0.0f, 1.0f, 0.5f, &r));
+}
+
+void numx_test_interpolate(void)
+{
+    RUN_TEST(test_linear_midpoint_known);
+    RUN_TEST(test_linear_second_interval);
+    RUN_TEST(test_linear_at_knots);
+    RUN_TEST(test_linear_clamp_below);
+    RUN_TEST(test_linear_clamp_above);
+    RUN_TEST(test_linear_n2);
+    RUN_TEST(test_linear_null);
+    RUN_TEST(test_linear_n_lt_2);
+    RUN_TEST(test_spline_linear_data_exact);
+    RUN_TEST(test_spline_cubic_oneshot_midpoint);
+    RUN_TEST(test_spline_at_knots);
+    RUN_TEST(test_spline_clamp_below);
+    RUN_TEST(test_spline_clamp_above);
+    RUN_TEST(test_spline_n2);
+    RUN_TEST(test_spline_precompute_null);
+    RUN_TEST(test_spline_precompute_n_lt_2);
+    RUN_TEST(test_cheb_constant);
+    RUN_TEST(test_cheb_linear_exact);
+    RUN_TEST(test_cheb_quadratic_exact);
+    RUN_TEST(test_cheb_quadratic_at_zero);
+    RUN_TEST(test_cheb_n2_gives_linear_interp);
+    RUN_TEST(test_cheb_null);
+    RUN_TEST(test_cheb_b_le_a);
+    RUN_TEST(test_cheb_n_lt_2);
+}

--- a/tests/x86/test_linalg.c
+++ b/tests/x86/test_linalg.c
@@ -1,0 +1,498 @@
+/**
+ * @file test_linalg.c
+ * @brief Linear algebra tests — float32 / x86 host build.
+ *        numx_real_t = float  (NUMX_USE_DOUBLE not set)
+ *
+ * L1 Known-answer | L2 Property | L3 Edge case | L4 Error handling
+ */
+
+#include "unity.h"
+#include "numx/numx_types.h"
+#include "numx/linalg.h"
+
+#define TOL    1e-5f
+#define TOL_LU 1e-4f
+
+/* ── numx_vec_dot ──────────────────────────────────────────────────── */
+
+void test_vec_dot_known(void)
+{
+    numx_real_t a[] = {1.0f, 2.0f, 3.0f};
+    numx_real_t b[] = {4.0f, 5.0f, 6.0f};
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_vec_dot(a, b, 3, &r));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 32.0f, r);
+}
+
+void test_vec_dot_orthogonal(void)
+{
+    numx_real_t a[] = {1.0f, 0.0f, 0.0f};
+    numx_real_t b[] = {0.0f, 1.0f, 0.0f};
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_vec_dot(a, b, 3, &r));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 0.0f, r);
+}
+
+void test_vec_dot_commutative(void)
+{
+    numx_real_t a[] = {1.0f, 2.0f, 3.0f};
+    numx_real_t b[] = {4.0f, 5.0f, 6.0f};
+    numx_real_t r1, r2;
+    numx_vec_dot(a, b, 3, &r1);
+    numx_vec_dot(b, a, 3, &r2);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, r1, r2);
+}
+
+void test_vec_dot_self_equals_sq_norm(void)
+{
+    numx_real_t a[] = {3.0f, 4.0f};
+    numx_real_t r;
+    numx_vec_dot(a, a, 2, &r);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 25.0f, r);
+}
+
+void test_vec_dot_single_element(void)
+{
+    numx_real_t a[] = {7.0f};
+    numx_real_t b[] = {3.0f};
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_vec_dot(a, b, 1, &r));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 21.0f, r);
+}
+
+void test_vec_dot_zero_vector(void)
+{
+    numx_real_t a[] = {0.0f, 0.0f, 0.0f};
+    numx_real_t b[] = {1.0f, 2.0f, 3.0f};
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_vec_dot(a, b, 3, &r));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 0.0f, r);
+}
+
+void test_vec_dot_null_a(void)
+{
+    numx_real_t b[] = {1.0f}, r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_vec_dot(NULL, b, 1, &r));
+}
+
+void test_vec_dot_null_b(void)
+{
+    numx_real_t a[] = {1.0f}, r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_vec_dot(a, NULL, 1, &r));
+}
+
+void test_vec_dot_null_result(void)
+{
+    numx_real_t a[] = {1.0f}, b[] = {1.0f};
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_vec_dot(a, b, 1, NULL));
+}
+
+void test_vec_dot_zero_n(void)
+{
+    numx_real_t a[] = {1.0f}, b[] = {1.0f}, r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_vec_dot(a, b, 0, &r));
+}
+
+/* ── numx_vec_norm ─────────────────────────────────────────────────── */
+
+void test_vec_norm_l2_pythagorean(void)
+{
+    numx_real_t a[] = {3.0f, 4.0f};
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_vec_norm(a, 2, NUMX_NORM_L2, &r));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 5.0f, r);
+}
+
+void test_vec_norm_l1_known(void)
+{
+    numx_real_t a[] = {3.0f, -4.0f, 0.0f};
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_vec_norm(a, 3, NUMX_NORM_L1, &r));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 7.0f, r);
+}
+
+void test_vec_norm_linf_known(void)
+{
+    numx_real_t a[] = {3.0f, -5.0f, 4.0f};
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_vec_norm(a, 3, NUMX_NORM_INF, &r));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 5.0f, r);
+}
+
+void test_vec_norm_unit_vector_is_one(void)
+{
+    numx_real_t a[] = {1.0f, 0.0f, 0.0f};
+    numx_real_t r;
+    numx_vec_norm(a, 3, NUMX_NORM_L2, &r);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 1.0f, r);
+}
+
+void test_vec_norm_zero_vector_is_zero(void)
+{
+    numx_real_t a[] = {0.0f, 0.0f, 0.0f};
+    numx_real_t r;
+    numx_vec_norm(a, 3, NUMX_NORM_L2, &r);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 0.0f, r);
+}
+
+void test_vec_norm_null_a(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_vec_norm(NULL, 3, NUMX_NORM_L2, &r));
+}
+
+void test_vec_norm_null_result(void)
+{
+    numx_real_t a[] = {1.0f, 2.0f};
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_vec_norm(a, 2, NUMX_NORM_L2, NULL));
+}
+
+void test_vec_norm_unknown_type(void)
+{
+    numx_real_t a[] = {1.0f}, r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_vec_norm(a, 1, (numx_norm_t)99, &r));
+}
+
+/* ── numx_vec_cross3 ───────────────────────────────────────────────── */
+
+void test_vec_cross3_x_cross_y(void)
+{
+    numx_real_t a[] = {1.0f, 0.0f, 0.0f};
+    numx_real_t b[] = {0.0f, 1.0f, 0.0f};
+    numx_real_t r[3];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_vec_cross3(a, b, r));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 0.0f, r[0]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 0.0f, r[1]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 1.0f, r[2]);
+}
+
+void test_vec_cross3_anticommutative(void)
+{
+    numx_real_t a[] = {1.0f, 2.0f, 3.0f};
+    numx_real_t b[] = {4.0f, 5.0f, 6.0f};
+    numx_real_t axb[3], bxa[3];
+    numx_vec_cross3(a, b, axb);
+    numx_vec_cross3(b, a, bxa);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, -axb[0], bxa[0]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, -axb[1], bxa[1]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, -axb[2], bxa[2]);
+}
+
+void test_vec_cross3_parallel_is_zero(void)
+{
+    numx_real_t a[] = {2.0f, 0.0f, 0.0f};
+    numx_real_t b[] = {5.0f, 0.0f, 0.0f};
+    numx_real_t r[3];
+    numx_vec_cross3(a, b, r);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 0.0f, r[0]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 0.0f, r[1]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 0.0f, r[2]);
+}
+
+void test_vec_cross3_alias_safe(void)
+{
+    numx_real_t a[] = {1.0f, 0.0f, 0.0f};
+    numx_real_t b[] = {0.0f, 1.0f, 0.0f};
+    numx_vec_cross3(a, b, a);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 0.0f, a[0]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 0.0f, a[1]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 1.0f, a[2]);
+}
+
+void test_vec_cross3_null(void)
+{
+    numx_real_t b[] = {1.0f, 0.0f, 0.0f}, r[3];
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_vec_cross3(NULL, b, r));
+}
+
+/* ── numx_mat_mul ──────────────────────────────────────────────────── */
+
+void test_mat_mul_2x2(void)
+{
+    numx_real_t A[] = {1.0f, 2.0f, 3.0f, 4.0f};
+    numx_real_t B[] = {5.0f, 6.0f, 7.0f, 8.0f};
+    numx_real_t C[4];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_mat_mul(A, 2, 2, B, 2, 2, C));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 19.0f, C[0]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 22.0f, C[1]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 43.0f, C[2]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 50.0f, C[3]);
+}
+
+void test_mat_mul_2x3_times_3x2(void)
+{
+    numx_real_t A[] = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+    numx_real_t B[] = {7.0f, 8.0f, 9.0f, 10.0f, 11.0f, 12.0f};
+    numx_real_t C[4];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_mat_mul(A, 2, 3, B, 3, 2, C));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 58.0f,  C[0]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 64.0f,  C[1]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 139.0f, C[2]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 154.0f, C[3]);
+}
+
+void test_mat_mul_identity(void)
+{
+    numx_real_t A[] = {1.0f, 2.0f, 3.0f, 4.0f};
+    numx_real_t I[] = {1.0f, 0.0f, 0.0f, 1.0f};
+    numx_real_t C[4];
+    numx_mat_mul(A, 2, 2, I, 2, 2, C);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, A[0], C[0]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, A[1], C[1]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, A[2], C[2]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, A[3], C[3]);
+}
+
+void test_mat_mul_dim_mismatch(void)
+{
+    numx_real_t A[6] = {0}, B[4] = {0}, C[4] = {0};
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_mat_mul(A, 2, 3, B, 2, 2, C));
+}
+
+void test_mat_mul_null_A(void)
+{
+    numx_real_t B[4] = {0}, C[4] = {0};
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_mat_mul(NULL, 2, 2, B, 2, 2, C));
+}
+
+/* ── numx_mat_transpose ────────────────────────────────────────────── */
+
+void test_mat_transpose_2x3(void)
+{
+    numx_real_t A[] = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+    numx_real_t AT[6];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_mat_transpose(A, 2, 3, AT));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 1.0f, AT[0]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 4.0f, AT[1]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 2.0f, AT[2]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 5.0f, AT[3]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 3.0f, AT[4]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 6.0f, AT[5]);
+}
+
+void test_mat_transpose_double_is_identity(void)
+{
+    numx_real_t A[] = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+    numx_real_t AT[6], ATT[6];
+    numx_size_t i;
+    numx_mat_transpose(A, 2, 3, AT);
+    numx_mat_transpose(AT, 3, 2, ATT);
+    for (i = 0; i < 6; i++)
+        TEST_ASSERT_FLOAT_WITHIN(TOL, A[i], ATT[i]);
+}
+
+void test_mat_transpose_sq_inplace(void)
+{
+    numx_real_t A[] = {1.0f, 2.0f, 3.0f, 4.0f};
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_mat_transpose_sq(A, 2));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 1.0f, A[0]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 3.0f, A[1]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 2.0f, A[2]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 4.0f, A[3]);
+}
+
+void test_mat_transpose_sq_twice_is_identity(void)
+{
+    numx_real_t A[] = {1.0f,2.0f,3.0f,4.0f,5.0f,6.0f,7.0f,8.0f,9.0f};
+    numx_real_t orig[9];
+    numx_size_t i;
+    for (i = 0; i < 9; i++) orig[i] = A[i];
+    numx_mat_transpose_sq(A, 3);
+    numx_mat_transpose_sq(A, 3);
+    for (i = 0; i < 9; i++)
+        TEST_ASSERT_FLOAT_WITHIN(TOL, orig[i], A[i]);
+}
+
+void test_mat_transpose_null(void)
+{
+    numx_real_t AT[4];
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_mat_transpose(NULL, 2, 2, AT));
+}
+
+void test_mat_transpose_sq_null(void)
+{
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_mat_transpose_sq(NULL, 2));
+}
+
+/* ── numx_mat_det ──────────────────────────────────────────────────── */
+
+void test_mat_det_1x1(void)
+{
+    numx_real_t A[] = {7.0f};
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_mat_det(A, 1, &r));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 7.0f, r);
+}
+
+void test_mat_det_2x2(void)
+{
+    numx_real_t A[] = {1.0f, 2.0f, 3.0f, 4.0f};
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_mat_det(A, 2, &r));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, -2.0f, r);
+}
+
+void test_mat_det_3x3(void)
+{
+    numx_real_t A[] = {1.0f,2.0f,3.0f,4.0f,5.0f,6.0f,7.0f,8.0f,10.0f};
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_mat_det(A, 3, &r));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, -3.0f, r);
+}
+
+void test_mat_det_identity_is_one(void)
+{
+    numx_real_t I[] = {1.0f,0.0f,0.0f,0.0f,1.0f,0.0f,0.0f,0.0f,1.0f};
+    numx_real_t r;
+    numx_mat_det(I, 3, &r);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 1.0f, r);
+}
+
+void test_mat_det_singular_is_zero(void)
+{
+    numx_real_t A[] = {1.0f, 2.0f, 2.0f, 4.0f};
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_mat_det(A, 2, &r));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 0.0f, r);
+}
+
+void test_mat_det_null(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_mat_det(NULL, 2, &r));
+}
+
+void test_mat_det_null_result(void)
+{
+    numx_real_t A[] = {1.0f, 0.0f, 0.0f, 1.0f};
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_mat_det(A, 2, NULL));
+}
+
+/* ── numx_lu_decompose / numx_lu_solve ────────────────────────────── */
+
+void test_lu_solve_3x3_textbook(void)
+{
+    numx_real_t A[] = { 2.0f, 1.0f,-1.0f,
+                       -3.0f,-1.0f, 2.0f,
+                       -2.0f, 1.0f, 2.0f};
+    numx_real_t b[] = {8.0f,-11.0f,-3.0f};
+    numx_real_t LU[9]; numx_idx_t pivot[3]; numx_real_t x[3];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_lu_decompose(A, 3, LU, pivot));
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_lu_solve(LU, pivot, 3, b, x));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_LU,  2.0f, x[0]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_LU,  3.0f, x[1]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_LU, -1.0f, x[2]);
+}
+
+void test_lu_solve_identity_system(void)
+{
+    numx_real_t A[] = {1.0f,0.0f,0.0f,1.0f};
+    numx_real_t b[] = {5.0f,7.0f};
+    numx_real_t LU[4]; numx_idx_t pivot[2]; numx_real_t x[2];
+    numx_lu_decompose(A, 2, LU, pivot);
+    numx_lu_solve(LU, pivot, 2, b, x);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 5.0f, x[0]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 7.0f, x[1]);
+}
+
+void test_lu_solve_residual_is_zero(void)
+{
+    numx_real_t A[] = { 2.0f, 1.0f,-1.0f,
+                       -3.0f,-1.0f, 2.0f,
+                       -2.0f, 1.0f, 2.0f};
+    numx_real_t b[] = {8.0f,-11.0f,-3.0f};
+    numx_real_t LU[9]; numx_idx_t pivot[3];
+    numx_real_t x[3], Ax[3];
+    numx_lu_decompose(A, 3, LU, pivot);
+    numx_lu_solve(LU, pivot, 3, b, x);
+    numx_mat_mul(A, 3, 3, x, 3, 1, Ax);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_LU, b[0], Ax[0]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_LU, b[1], Ax[1]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_LU, b[2], Ax[2]);
+}
+
+void test_lu_decompose_singular(void)
+{
+    numx_real_t A[] = {1.0f,2.0f,2.0f,4.0f};
+    numx_real_t LU[4]; numx_idx_t pivot[2];
+    TEST_ASSERT_EQUAL(NUMX_ERR_SINGULAR, numx_lu_decompose(A, 2, LU, pivot));
+}
+
+void test_lu_decompose_null_A(void)
+{
+    numx_real_t LU[4]; numx_idx_t pivot[2];
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_lu_decompose(NULL, 2, LU, pivot));
+}
+
+void test_lu_decompose_null_LU(void)
+{
+    numx_real_t A[4] = {0}; numx_idx_t pivot[2] = {0};
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_lu_decompose(A, 2, NULL, pivot));
+}
+
+void test_lu_solve_null_LU(void)
+{
+    numx_real_t b[2] = {0}, x[2] = {0}; numx_idx_t pivot[2] = {0,1};
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_lu_solve(NULL, pivot, 2, b, x));
+}
+
+void test_lu_solve_null_x(void)
+{
+    numx_real_t LU[4] = {1,0,0,1}, b[2] = {1,1}; numx_idx_t pivot[2] = {0,1};
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_lu_solve(LU, pivot, 2, b, NULL));
+}
+
+/* ── Suite entry point ─────────────────────────────────────────────── */
+
+void numx_test_linalg(void)
+{
+    RUN_TEST(test_vec_dot_known);
+    RUN_TEST(test_vec_dot_orthogonal);
+    RUN_TEST(test_vec_dot_commutative);
+    RUN_TEST(test_vec_dot_self_equals_sq_norm);
+    RUN_TEST(test_vec_dot_single_element);
+    RUN_TEST(test_vec_dot_zero_vector);
+    RUN_TEST(test_vec_dot_null_a);
+    RUN_TEST(test_vec_dot_null_b);
+    RUN_TEST(test_vec_dot_null_result);
+    RUN_TEST(test_vec_dot_zero_n);
+    RUN_TEST(test_vec_norm_l2_pythagorean);
+    RUN_TEST(test_vec_norm_l1_known);
+    RUN_TEST(test_vec_norm_linf_known);
+    RUN_TEST(test_vec_norm_unit_vector_is_one);
+    RUN_TEST(test_vec_norm_zero_vector_is_zero);
+    RUN_TEST(test_vec_norm_null_a);
+    RUN_TEST(test_vec_norm_null_result);
+    RUN_TEST(test_vec_norm_unknown_type);
+    RUN_TEST(test_vec_cross3_x_cross_y);
+    RUN_TEST(test_vec_cross3_anticommutative);
+    RUN_TEST(test_vec_cross3_parallel_is_zero);
+    RUN_TEST(test_vec_cross3_alias_safe);
+    RUN_TEST(test_vec_cross3_null);
+    RUN_TEST(test_mat_mul_2x2);
+    RUN_TEST(test_mat_mul_2x3_times_3x2);
+    RUN_TEST(test_mat_mul_identity);
+    RUN_TEST(test_mat_mul_dim_mismatch);
+    RUN_TEST(test_mat_mul_null_A);
+    RUN_TEST(test_mat_transpose_2x3);
+    RUN_TEST(test_mat_transpose_double_is_identity);
+    RUN_TEST(test_mat_transpose_sq_inplace);
+    RUN_TEST(test_mat_transpose_sq_twice_is_identity);
+    RUN_TEST(test_mat_transpose_null);
+    RUN_TEST(test_mat_transpose_sq_null);
+    RUN_TEST(test_mat_det_1x1);
+    RUN_TEST(test_mat_det_2x2);
+    RUN_TEST(test_mat_det_3x3);
+    RUN_TEST(test_mat_det_identity_is_one);
+    RUN_TEST(test_mat_det_singular_is_zero);
+    RUN_TEST(test_mat_det_null);
+    RUN_TEST(test_mat_det_null_result);
+    RUN_TEST(test_lu_solve_3x3_textbook);
+    RUN_TEST(test_lu_solve_identity_system);
+    RUN_TEST(test_lu_solve_residual_is_zero);
+    RUN_TEST(test_lu_decompose_singular);
+    RUN_TEST(test_lu_decompose_null_A);
+    RUN_TEST(test_lu_decompose_null_LU);
+    RUN_TEST(test_lu_solve_null_LU);
+    RUN_TEST(test_lu_solve_null_x);
+}

--- a/tests/x86/test_ode.c
+++ b/tests/x86/test_ode.c
@@ -1,0 +1,217 @@
+/**
+ * @file test_ode.c
+ * @brief ODE solver tests — float32 / x86 host build.
+ *        numx_real_t = float  (NUMX_USE_DOUBLE not set)
+ */
+
+#include "unity.h"
+#include "numx/numx_types.h"
+#include "numx/ode.h"
+
+#define TOL_RK4  1e-3f
+#define TOL_RK45 1e-3f
+#define RK45_TOL 1e-4f
+
+static numx_status_t ode_growth(numx_real_t t, const numx_real_t *y,
+                                numx_size_t n, numx_real_t *dydt)
+{
+    numx_size_t i; (void)t;
+    for (i = 0; i < n; i++) dydt[i] = y[i];
+    return NUMX_OK;
+}
+
+static numx_status_t ode_decay(numx_real_t t, const numx_real_t *y,
+                               numx_size_t n, numx_real_t *dydt)
+{
+    numx_size_t i; (void)t;
+    for (i = 0; i < n; i++) dydt[i] = -y[i];
+    return NUMX_OK;
+}
+
+static numx_status_t ode_harmonic(numx_real_t t, const numx_real_t *y,
+                                  numx_size_t n, numx_real_t *dydt)
+{
+    (void)t; (void)n;
+    dydt[0] =  y[1];
+    dydt[1] = -y[0];
+    return NUMX_OK;
+}
+
+static numx_status_t ode_error(numx_real_t t, const numx_real_t *y,
+                               numx_size_t n, numx_real_t *dydt)
+{
+    (void)t; (void)y; (void)n; (void)dydt;
+    return NUMX_ERR_SINGULAR;
+}
+
+void test_rk4_growth_at_t1(void)
+{
+    numx_real_t y[] = {1.0f};
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_ode_rk4(ode_growth, 0.0f, y, 1, 1e-3f, 1000, y));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_RK4, 2.71828f, y[0]);
+}
+
+void test_rk4_decay_at_t1(void)
+{
+    numx_real_t y[] = {1.0f};
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_ode_rk4(ode_decay, 0.0f, y, 1, 1e-3f, 1000, y));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_RK4, 0.36788f, y[0]);
+}
+
+void test_rk4_growth_at_t2(void)
+{
+    numx_real_t y[] = {1.0f};
+    numx_ode_rk4(ode_growth, 0.0f, y, 1, 1e-3f, 2000, y);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_RK4, 7.38906f, y[0]);
+}
+
+void test_rk4_harmonic_energy_conserved(void)
+{
+    numx_real_t y[] = {1.0f, 0.0f};
+    numx_real_t E_init  = 0.5f*(y[0]*y[0]+y[1]*y[1]);
+    numx_ode_rk4(ode_harmonic, 0.0f, y, 2, 1e-3f, 1000, y);
+    numx_real_t E_final = 0.5f*(y[0]*y[0]+y[1]*y[1]);
+    numx_real_t err = E_final-E_init;
+    if (err < 0.0f) err = -err;
+    TEST_ASSERT_TRUE(err < 1e-2f);
+}
+
+void test_rk4_single_step(void)
+{
+    numx_real_t y[] = {1.0f};
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_ode_rk4(ode_growth, 0.0f, y, 1, 0.01f, 1, y));
+    TEST_ASSERT_FLOAT_WITHIN(1e-4f, 1.01005f, y[0]);
+}
+
+void test_rk4_propagates_rhs_error(void)
+{
+    numx_real_t y[] = {1.0f};
+    TEST_ASSERT_EQUAL(NUMX_ERR_SINGULAR,
+                      numx_ode_rk4(ode_error, 0.0f, y, 1, 0.1f, 10, y));
+}
+
+void test_rk4_null(void)
+{
+    numx_real_t y0[] = {1.0f}, y[1];
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_ode_rk4(NULL, 0.0f, y0, 1, 0.1f, 10, y));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_ode_rk4(ode_growth, 0.0f, NULL, 1, 0.1f, 10, y));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_ode_rk4(ode_growth, 0.0f, y0, 1, 0.1f, 10, NULL));
+}
+
+void test_rk4_h_nonpositive(void)
+{
+    numx_real_t y0[] = {1.0f}, y[1];
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_ode_rk4(ode_growth, 0.0f, y0, 1, 0.0f, 10, y));
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_ode_rk4(ode_growth, 0.0f, y0, 1, -1.0f, 10, y));
+}
+
+void test_rk4_steps_zero(void)
+{
+    numx_real_t y0[] = {1.0f}, y[1];
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_ode_rk4(ode_growth, 0.0f, y0, 1, 0.1f, 0, y));
+}
+
+void test_rk4_n_zero(void)
+{
+    numx_real_t y0[] = {1.0f}, y[1];
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_ode_rk4(ode_growth, 0.0f, y0, 0, 0.1f, 10, y));
+}
+
+void test_rk45_growth_at_t1(void)
+{
+    numx_real_t y[] = {1.0f};
+    TEST_ASSERT_EQUAL(NUMX_OK,
+                      numx_ode_rk45(ode_growth, 0.0f, 1.0f, y, 1, RK45_TOL, y));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_RK45, 2.71828f, y[0]);
+}
+
+void test_rk45_decay_at_t1(void)
+{
+    numx_real_t y[] = {1.0f};
+    TEST_ASSERT_EQUAL(NUMX_OK,
+                      numx_ode_rk45(ode_decay, 0.0f, 1.0f, y, 1, RK45_TOL, y));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_RK45, 0.36788f, y[0]);
+}
+
+void test_rk45_harmonic_energy_conserved(void)
+{
+    numx_real_t y[] = {1.0f, 0.0f};
+    numx_real_t E_init  = 0.5f*(y[0]*y[0]+y[1]*y[1]);
+    numx_ode_rk45(ode_harmonic, 0.0f, 10.0f, y, 2, RK45_TOL, y);
+    numx_real_t E_final = 0.5f*(y[0]*y[0]+y[1]*y[1]);
+    numx_real_t err = E_final-E_init;
+    if (err < 0.0f) err = -err;
+    TEST_ASSERT_TRUE(err < 1e-2f);
+}
+
+void test_rk45_propagates_rhs_error(void)
+{
+    numx_real_t y[] = {1.0f};
+    TEST_ASSERT_EQUAL(NUMX_ERR_SINGULAR,
+                      numx_ode_rk45(ode_error, 0.0f, 1.0f, y, 1, RK45_TOL, y));
+}
+
+void test_rk45_null(void)
+{
+    numx_real_t y0[] = {1.0f}, y[1];
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_ode_rk45(NULL, 0.0f, 1.0f, y0, 1, RK45_TOL, y));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_ode_rk45(ode_growth, 0.0f, 1.0f, NULL, 1, RK45_TOL, y));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_ode_rk45(ode_growth, 0.0f, 1.0f, y0, 1, RK45_TOL, NULL));
+}
+
+void test_rk45_t1_le_t0(void)
+{
+    numx_real_t y0[] = {1.0f}, y[1];
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_ode_rk45(ode_growth, 1.0f, 0.0f, y0, 1, RK45_TOL, y));
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_ode_rk45(ode_growth, 1.0f, 1.0f, y0, 1, RK45_TOL, y));
+}
+
+void test_rk45_tol_nonpositive(void)
+{
+    numx_real_t y0[] = {1.0f}, y[1];
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_ode_rk45(ode_growth, 0.0f, 1.0f, y0, 1, 0.0f, y));
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_ode_rk45(ode_growth, 0.0f, 1.0f, y0, 1, -1e-3f, y));
+}
+
+void test_rk45_n_zero(void)
+{
+    numx_real_t y0[] = {1.0f}, y[1];
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_ode_rk45(ode_growth, 0.0f, 1.0f, y0, 0, RK45_TOL, y));
+}
+
+void numx_test_ode(void)
+{
+    RUN_TEST(test_rk4_growth_at_t1);
+    RUN_TEST(test_rk4_decay_at_t1);
+    RUN_TEST(test_rk4_growth_at_t2);
+    RUN_TEST(test_rk4_harmonic_energy_conserved);
+    RUN_TEST(test_rk4_single_step);
+    RUN_TEST(test_rk4_propagates_rhs_error);
+    RUN_TEST(test_rk4_null);
+    RUN_TEST(test_rk4_h_nonpositive);
+    RUN_TEST(test_rk4_steps_zero);
+    RUN_TEST(test_rk4_n_zero);
+    RUN_TEST(test_rk45_growth_at_t1);
+    RUN_TEST(test_rk45_decay_at_t1);
+    RUN_TEST(test_rk45_harmonic_energy_conserved);
+    RUN_TEST(test_rk45_propagates_rhs_error);
+    RUN_TEST(test_rk45_null);
+    RUN_TEST(test_rk45_t1_le_t0);
+    RUN_TEST(test_rk45_tol_nonpositive);
+    RUN_TEST(test_rk45_n_zero);
+}

--- a/tests/x86/test_poly.c
+++ b/tests/x86/test_poly.c
@@ -1,0 +1,174 @@
+/**
+ * @file test_poly.c
+ * @brief Polynomial tests — float32 / x86 host build.
+ *        numx_real_t = float  (NUMX_USE_DOUBLE not set)
+ */
+
+#include "unity.h"
+#include "numx/numx_types.h"
+#include "numx/poly.h"
+
+#define TOL      1e-4f
+#define TOL_ROOT 1e-3f
+
+static numx_real_t priv_absf(numx_real_t x){ return x < 0.0f ? -x : x; }
+
+static numx_real_t poly_at(const numx_real_t *c, numx_size_t deg, numx_real_t x)
+{
+    numx_real_t acc = c[0]; numx_size_t i;
+    for (i = 1; i <= deg; i++) acc = acc*x + c[i];
+    return acc;
+}
+
+void test_poly_eval_quadratic_at_3(void)
+{
+    numx_real_t c[] = {1.0f,0.0f,1.0f}, r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_poly_eval(c, 2, 3.0f, &r));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 10.0f, r);
+}
+
+void test_poly_eval_cubic_at_2(void)
+{
+    numx_real_t c[] = {1.0f,0.0f,-2.0f,1.0f}, r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_poly_eval(c, 3, 2.0f, &r));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 5.0f, r);
+}
+
+void test_poly_eval_at_zero(void)
+{
+    numx_real_t c[] = {3.0f,7.0f,-2.0f}, r;
+    numx_poly_eval(c, 2, 0.0f, &r);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, -2.0f, r);
+}
+
+void test_poly_eval_at_one(void)
+{
+    numx_real_t c[] = {1.0f,-3.0f,2.0f}, r;
+    numx_poly_eval(c, 2, 1.0f, &r);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 0.0f, r);
+}
+
+void test_poly_eval_degree_0(void)
+{
+    numx_real_t c[] = {5.0f}, r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_poly_eval(c, 0, 99.0f, &r));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 5.0f, r);
+}
+
+void test_poly_eval_horner_consistency(void)
+{
+    numx_real_t c[] = {2.0f,3.0f,4.0f}, r;
+    numx_poly_eval(c, 2, 5.0f, &r);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 69.0f, r);
+}
+
+void test_poly_eval_null_coeffs(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_poly_eval(NULL, 2, 1.0f, &r));
+}
+
+void test_poly_eval_null_result(void)
+{
+    numx_real_t c[] = {1.0f,0.0f,0.0f};
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_poly_eval(c, 2, 1.0f, NULL));
+}
+
+void test_poly_roots_linear(void)
+{
+    numx_real_t c[] = {1.0f,1.0f};
+    numx_real_t roots[1]; numx_size_t nroots;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_poly_roots(c, 1, roots, &nroots, TOL_ROOT));
+    TEST_ASSERT_EQUAL(1, (int)nroots);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, -1.0f, roots[0]);
+}
+
+void test_poly_roots_quadratic_two_reals(void)
+{
+    numx_real_t c[] = {1.0f,-5.0f,6.0f};
+    numx_real_t roots[2]; numx_size_t nroots;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_poly_roots(c, 2, roots, &nroots, TOL_ROOT));
+    TEST_ASSERT_EQUAL(2, (int)nroots);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 0.0f, poly_at(c, 2, roots[0]));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 0.0f, poly_at(c, 2, roots[1]));
+}
+
+void test_poly_roots_quadratic_root_values(void)
+{
+    numx_real_t c[] = {1.0f,-5.0f,6.0f};
+    numx_real_t roots[2]; numx_size_t nroots;
+    numx_real_t lo, hi, tmp;
+    numx_poly_roots(c, 2, roots, &nroots, TOL_ROOT);
+    lo = roots[0]; hi = roots[1];
+    if (lo > hi) { tmp=lo; lo=hi; hi=tmp; }
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 2.0f, lo);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 3.0f, hi);
+}
+
+void test_poly_roots_cubic_residuals(void)
+{
+    numx_real_t c[] = {1.0f,-6.0f,11.0f,-6.0f};
+    numx_real_t roots[3]; numx_size_t nroots, i;
+    numx_poly_roots(c, 3, roots, &nroots, TOL_ROOT);
+    for (i = 0; i < nroots; i++)
+        TEST_ASSERT_TRUE(priv_absf(poly_at(c, 3, roots[i])) < TOL);
+}
+
+void test_poly_roots_single_real_found(void)
+{
+    numx_real_t c[] = {1.0f,0.0f,0.0f,-8.0f};
+    numx_real_t roots[3]; numx_size_t nroots; int found = 0; numx_size_t i;
+    numx_poly_roots(c, 3, roots, &nroots, TOL_ROOT);
+    TEST_ASSERT_TRUE(nroots >= 1);
+    for (i = 0; i < nroots; i++)
+        if (priv_absf(roots[i]-2.0f) < TOL) found = 1;
+    TEST_ASSERT_TRUE(found);
+}
+
+void test_poly_roots_null(void)
+{
+    numx_real_t c[] = {1.0f,0.0f,-1.0f};
+    numx_real_t roots[2]; numx_size_t nroots;
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_poly_roots(NULL, 2, roots, &nroots, TOL_ROOT));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_poly_roots(c, 2, NULL, &nroots, TOL_ROOT));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_poly_roots(c, 2, roots, NULL, TOL_ROOT));
+}
+
+void test_poly_roots_degree_zero_rejected(void)
+{
+    numx_real_t c[] = {1.0f};
+    numx_real_t roots[1]; numx_size_t nroots;
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_poly_roots(c, 0, roots, &nroots, TOL_ROOT));
+}
+
+void test_poly_roots_tol_nonpositive(void)
+{
+    numx_real_t c[] = {1.0f,-1.0f};
+    numx_real_t roots[1]; numx_size_t nroots;
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_poly_roots(c, 1, roots, &nroots, 0.0f));
+}
+
+void numx_test_poly(void)
+{
+    RUN_TEST(test_poly_eval_quadratic_at_3);
+    RUN_TEST(test_poly_eval_cubic_at_2);
+    RUN_TEST(test_poly_eval_at_zero);
+    RUN_TEST(test_poly_eval_at_one);
+    RUN_TEST(test_poly_eval_degree_0);
+    RUN_TEST(test_poly_eval_horner_consistency);
+    RUN_TEST(test_poly_eval_null_coeffs);
+    RUN_TEST(test_poly_eval_null_result);
+    RUN_TEST(test_poly_roots_linear);
+    RUN_TEST(test_poly_roots_quadratic_two_reals);
+    RUN_TEST(test_poly_roots_quadratic_root_values);
+    RUN_TEST(test_poly_roots_cubic_residuals);
+    RUN_TEST(test_poly_roots_single_real_found);
+    RUN_TEST(test_poly_roots_null);
+    RUN_TEST(test_poly_roots_degree_zero_rejected);
+    RUN_TEST(test_poly_roots_tol_nonpositive);
+}

--- a/tests/x86/test_roots.c
+++ b/tests/x86/test_roots.c
@@ -1,0 +1,237 @@
+/**
+ * @file test_roots.c
+ * @brief Root-finding tests — float32 / x86 host build.
+ *        numx_real_t = float  (NUMX_USE_DOUBLE not set)
+ */
+
+#include "unity.h"
+#include "numx/numx_types.h"
+#include "numx/roots.h"
+
+#define TOL      1e-5f
+#define ROOT_TOL 1e-5f
+
+static numx_real_t f_linear(numx_real_t x)   { return x - (numx_real_t)2.0; }
+static numx_real_t df_linear(numx_real_t x)  { (void)x; return (numx_real_t)1.0; }
+static numx_real_t f_quadratic(numx_real_t x) { return x*x - (numx_real_t)4.0; }
+static numx_real_t df_quadratic(numx_real_t x){ return (numx_real_t)2.0*x; }
+static numx_real_t f_cubic(numx_real_t x)     { return x*x*x - x; }
+static numx_real_t df_cubic(numx_real_t x)    { return (numx_real_t)3.0*x*x - (numx_real_t)1.0; }
+
+static numx_real_t f_double_root(numx_real_t x)
+{ numx_real_t d = x-(numx_real_t)1.0; return d*d; }
+static numx_real_t df_double_root(numx_real_t x)
+{ return (numx_real_t)2.0*(x-(numx_real_t)1.0); }
+
+void test_bisect_linear(void)
+{
+    numx_real_t root;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_root_bisect(f_linear, 0.0f, 5.0f, ROOT_TOL, &root));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 2.0f, root);
+}
+
+void test_bisect_quadratic_positive(void)
+{
+    numx_real_t root;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_root_bisect(f_quadratic, 0.0f, 5.0f, ROOT_TOL, &root));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 2.0f, root);
+}
+
+void test_bisect_quadratic_negative(void)
+{
+    numx_real_t root;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_root_bisect(f_quadratic, -5.0f, 0.0f, ROOT_TOL, &root));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, -2.0f, root);
+}
+
+void test_bisect_residual_near_zero(void)
+{
+    numx_real_t root, residual;
+    numx_root_bisect(f_cubic, 0.5f, 2.0f, ROOT_TOL, &root);
+    residual = f_cubic(root);
+    if (residual < 0.0f) residual = -residual;
+    TEST_ASSERT_TRUE(residual < 1e-3f);
+}
+
+void test_bisect_root_at_left_endpoint(void)
+{
+    numx_real_t root;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_root_bisect(f_linear, 2.0f, 5.0f, ROOT_TOL, &root));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 2.0f, root);
+}
+
+void test_bisect_root_at_right_endpoint(void)
+{
+    numx_real_t root;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_root_bisect(f_linear, 0.0f, 2.0f, ROOT_TOL, &root));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 2.0f, root);
+}
+
+void test_bisect_null_f(void)
+{
+    numx_real_t root;
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_root_bisect(NULL, 0.0f, 1.0f, ROOT_TOL, &root));
+}
+
+void test_bisect_null_root(void)
+{
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_root_bisect(f_linear, 0.0f, 5.0f, ROOT_TOL, NULL));
+}
+
+void test_bisect_no_bracket(void)
+{
+    numx_real_t root;
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_root_bisect(f_quadratic, 3.0f, 5.0f, ROOT_TOL, &root));
+}
+
+void test_bisect_tol_zero(void)
+{
+    numx_real_t root;
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_root_bisect(f_linear, 0.0f, 5.0f, 0.0f, &root));
+}
+
+void test_newton_linear(void)
+{
+    numx_real_t root;
+    TEST_ASSERT_EQUAL(NUMX_OK,
+                      numx_root_newton(f_linear, df_linear, 0.0f, ROOT_TOL, &root));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 2.0f, root);
+}
+
+void test_newton_quadratic(void)
+{
+    numx_real_t root;
+    TEST_ASSERT_EQUAL(NUMX_OK,
+                      numx_root_newton(f_quadratic, df_quadratic, 3.0f, ROOT_TOL, &root));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 2.0f, root);
+}
+
+void test_newton_residual_near_zero(void)
+{
+    numx_real_t root, res;
+    numx_root_newton(f_cubic, df_cubic, 2.0f, ROOT_TOL, &root);
+    res = f_cubic(root);
+    if (res < 0.0f) res = -res;
+    TEST_ASSERT_TRUE(res < 1e-3f);
+}
+
+void test_newton_already_at_root(void)
+{
+    numx_real_t root;
+    TEST_ASSERT_EQUAL(NUMX_OK,
+                      numx_root_newton(f_linear, df_linear, 2.0f, ROOT_TOL, &root));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 2.0f, root);
+}
+
+void test_newton_null_f(void)
+{
+    numx_real_t root;
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_root_newton(NULL, df_linear, 0.0f, ROOT_TOL, &root));
+}
+
+void test_newton_null_df(void)
+{
+    numx_real_t root;
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_root_newton(f_linear, NULL, 0.0f, ROOT_TOL, &root));
+}
+
+void test_newton_zero_derivative(void)
+{
+    numx_real_t root;
+    numx_status_t s = numx_root_newton(f_double_root, df_double_root,
+                                       1.0f, ROOT_TOL, &root);
+    TEST_ASSERT_TRUE(s == NUMX_OK || s == NUMX_ERR_SINGULAR);
+}
+
+void test_newton_tol_negative(void)
+{
+    numx_real_t root;
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_root_newton(f_linear, df_linear, 0.0f, -1.0f, &root));
+}
+
+void test_brent_linear(void)
+{
+    numx_real_t root;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_root_brent(f_linear, 0.0f, 5.0f, ROOT_TOL, &root));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 2.0f, root);
+}
+
+void test_brent_quadratic(void)
+{
+    numx_real_t root;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_root_brent(f_quadratic, 0.0f, 5.0f, ROOT_TOL, &root));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 2.0f, root);
+}
+
+void test_brent_cubic_root_at_one(void)
+{
+    numx_real_t root;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_root_brent(f_cubic, 0.5f, 1.5f, ROOT_TOL, &root));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 1.0f, root);
+}
+
+void test_brent_residual_near_zero(void)
+{
+    numx_real_t root, res;
+    numx_root_brent(f_cubic, -1.5f, -0.5f, ROOT_TOL, &root);
+    res = f_cubic(root);
+    if (res < 0.0f) res = -res;
+    TEST_ASSERT_TRUE(res < 1e-3f);
+}
+
+void test_brent_null(void)
+{
+    numx_real_t root;
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_root_brent(NULL, 0.0f, 5.0f, ROOT_TOL, &root));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_root_brent(f_linear, 0.0f, 5.0f, ROOT_TOL, NULL));
+}
+
+void test_brent_no_bracket(void)
+{
+    numx_real_t root;
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_root_brent(f_quadratic, 3.0f, 5.0f, ROOT_TOL, &root));
+}
+
+void test_brent_tol_zero(void)
+{
+    numx_real_t root;
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_root_brent(f_linear, 0.0f, 5.0f, 0.0f, &root));
+}
+
+void numx_test_roots(void)
+{
+    RUN_TEST(test_bisect_linear);
+    RUN_TEST(test_bisect_quadratic_positive);
+    RUN_TEST(test_bisect_quadratic_negative);
+    RUN_TEST(test_bisect_residual_near_zero);
+    RUN_TEST(test_bisect_root_at_left_endpoint);
+    RUN_TEST(test_bisect_root_at_right_endpoint);
+    RUN_TEST(test_bisect_null_f);
+    RUN_TEST(test_bisect_null_root);
+    RUN_TEST(test_bisect_no_bracket);
+    RUN_TEST(test_bisect_tol_zero);
+    RUN_TEST(test_newton_linear);
+    RUN_TEST(test_newton_quadratic);
+    RUN_TEST(test_newton_residual_near_zero);
+    RUN_TEST(test_newton_already_at_root);
+    RUN_TEST(test_newton_null_f);
+    RUN_TEST(test_newton_null_df);
+    RUN_TEST(test_newton_zero_derivative);
+    RUN_TEST(test_newton_tol_negative);
+    RUN_TEST(test_brent_linear);
+    RUN_TEST(test_brent_quadratic);
+    RUN_TEST(test_brent_cubic_root_at_one);
+    RUN_TEST(test_brent_residual_near_zero);
+    RUN_TEST(test_brent_null);
+    RUN_TEST(test_brent_no_bracket);
+    RUN_TEST(test_brent_tol_zero);
+}

--- a/tests/x86/test_runner.c
+++ b/tests/x86/test_runner.c
@@ -1,0 +1,47 @@
+/**
+ * @file test_runner.c
+ * @brief numx master test runner — float32 / x86 host build.
+ *
+ * Compile with the CMakeLists.txt in this directory.
+ * numx_real_t = float (NUMX_USE_DOUBLE is NOT defined).
+ */
+
+#include "unity.h"
+
+void numx_test_linalg(void);
+void numx_test_stats(void);
+void numx_test_roots(void);
+void numx_test_integrate(void);
+void numx_test_differentiate(void);
+void numx_test_interpolate(void);
+void numx_test_poly(void);
+void numx_test_ode(void);
+void numx_test_signal(void);
+void numx_test_fft(void);
+void numx_test_autodiff(void);
+void numx_test_compressed_sensing(void);
+void numx_test_sketch(void);
+
+void setUp(void) {}
+void tearDown(void) {}
+
+int main(void)
+{
+    UNITY_BEGIN();
+
+    numx_test_linalg();
+    numx_test_stats();
+    numx_test_roots();
+    numx_test_integrate();
+    numx_test_differentiate();
+    numx_test_interpolate();
+    numx_test_poly();
+    numx_test_ode();
+    numx_test_signal();
+    numx_test_fft();
+    numx_test_autodiff();
+    numx_test_compressed_sensing();
+    numx_test_sketch();
+
+    return UNITY_END();
+}

--- a/tests/x86/test_signal.c
+++ b/tests/x86/test_signal.c
@@ -1,0 +1,279 @@
+/**
+ * @file test_signal.c
+ * @brief Signal processing tests — float32 / x86 host build.
+ *        numx_real_t = float  (NUMX_USE_DOUBLE not set)
+ */
+
+#include "unity.h"
+#include "numx/signal.h"
+
+#define TOL 1e-4f
+
+void test_window_rect_all_ones(void)
+{
+    numx_real_t w[8]; numx_size_t i;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_signal_window_rect(8, w));
+    for (i = 0; i < 8; i++) TEST_ASSERT_FLOAT_WITHIN(TOL, 1.0f, w[i]);
+}
+
+void test_window_rect_n1(void)
+{
+    numx_real_t w[1];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_signal_window_rect(1, w));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 1.0f, w[0]);
+}
+
+void test_window_hann_endpoints_zero(void)
+{
+    numx_real_t w[5];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_signal_window_hann(5, w));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 0.0f, w[0]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 0.0f, w[4]);
+}
+
+void test_window_hann_midpoint_one(void)
+{
+    numx_real_t w[5];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_signal_window_hann(5, w));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 1.0f, w[2]);
+}
+
+void test_window_hann_n1_returns_one(void)
+{
+    numx_real_t w[1];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_signal_window_hann(1, w));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 1.0f, w[0]);
+}
+
+void test_window_hamming_endpoints(void)
+{
+    numx_real_t w[5];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_signal_window_hamming(5, w));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 0.08f, w[0]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 0.08f, w[4]);
+}
+
+void test_window_hamming_midpoint_one(void)
+{
+    numx_real_t w[5];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_signal_window_hamming(5, w));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 1.0f, w[2]);
+}
+
+void test_window_blackman_endpoints_zero(void)
+{
+    numx_real_t w[5];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_signal_window_blackman(5, w));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 0.0f, w[0]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 0.0f, w[4]);
+}
+
+void test_window_blackman_midpoint_one(void)
+{
+    numx_real_t w[5];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_signal_window_blackman(5, w));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 1.0f, w[2]);
+}
+
+void test_convolve_box(void)
+{
+    numx_real_t x[] = {1.0f,1.0f,1.0f}, h[] = {1.0f,1.0f,1.0f}, out[5];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_signal_convolve(x, 3, h, 3, out));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 1.0f, out[0]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 2.0f, out[1]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 3.0f, out[2]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 2.0f, out[3]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 1.0f, out[4]);
+}
+
+void test_convolve_unit_impulse(void)
+{
+    numx_real_t x[] = {1.0f,0.0f,0.0f}, h[] = {3.0f,2.0f,1.0f}, out[5];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_signal_convolve(x, 3, h, 3, out));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 3.0f, out[0]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 2.0f, out[1]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 1.0f, out[2]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 0.0f, out[3]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 0.0f, out[4]);
+}
+
+void test_convolve_null_returns_error(void)
+{
+    numx_real_t x[2]={0},h[2]={0},out[3]={0};
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_signal_convolve(NULL,2,h,2,out));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_signal_convolve(x,2,NULL,2,out));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_signal_convolve(x,2,h,2,NULL));
+}
+
+void test_correlate_autocorr_peak_at_lag0(void)
+{
+    numx_real_t x[] = {1.0f,1.0f,1.0f}, out[5];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_signal_correlate(x, 3, x, 3, out));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 3.0f, out[2]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 2.0f, out[1]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 2.0f, out[3]);
+}
+
+void test_correlate_output_length(void)
+{
+    numx_real_t x[] = {1.0f,2.0f}, y[] = {1.0f,0.0f,0.0f}, out[4];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_signal_correlate(x, 2, y, 3, out));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 0.0f, out[0]);
+}
+
+void test_fir_identity_tap(void)
+{
+    numx_real_t x[] = {1.0f,2.0f,3.0f}, taps[] = {1.0f}, out[3];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_signal_fir(x, 3, taps, 1, out));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 1.0f, out[0]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 2.0f, out[1]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 3.0f, out[2]);
+}
+
+void test_fir_moving_average(void)
+{
+    numx_real_t x[] = {3.0f,3.0f,3.0f,3.0f,3.0f};
+    numx_real_t third = 1.0f/3.0f;
+    numx_real_t taps[] = {third,third,third}, out[5];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_signal_fir(x, 5, taps, 3, out));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 1.0f, out[0]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 2.0f, out[1]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 3.0f, out[2]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 3.0f, out[3]);
+}
+
+void test_fir_null_returns_error(void)
+{
+    numx_real_t x[2]={0},taps[1]={1.0f},out[2]={0};
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_signal_fir(NULL,2,taps,1,out));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_signal_fir(x,2,NULL,1,out));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_signal_fir(x,2,taps,1,NULL));
+}
+
+void test_iir_biquad_identity(void)
+{
+    numx_real_t x[]={1.0f,2.0f,3.0f},b[]={1.0f,0.0f,0.0f},a[]={0.0f,0.0f},out[3];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_signal_iir_biquad(x,3,b,a,out));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 1.0f, out[0]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 2.0f, out[1]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 3.0f, out[2]);
+}
+
+void test_iir_biquad_scale(void)
+{
+    numx_real_t x[]={1.0f,2.0f,3.0f},b[]={2.0f,0.0f,0.0f},a[]={0.0f,0.0f},out[3];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_signal_iir_biquad(x,3,b,a,out));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 2.0f, out[0]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 4.0f, out[1]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 6.0f, out[2]);
+}
+
+void test_iir_biquad_null_returns_error(void)
+{
+    numx_real_t x[2]={0},b[]={1,0,0},a[]={0,0},out[2]={0};
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_signal_iir_biquad(NULL,2,b,a,out));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_signal_iir_biquad(x,2,NULL,a,out));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_signal_iir_biquad(x,2,b,NULL,out));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_signal_iir_biquad(x,2,b,a,NULL));
+}
+
+void test_peaks_two_peaks(void)
+{
+    numx_real_t x[] = {0.0f,1.0f,0.0f,2.0f,0.0f};
+    numx_size_t peaks[5], npeaks;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_signal_peaks(x, 5, peaks, 5, &npeaks));
+    TEST_ASSERT_EQUAL(2, npeaks);
+    TEST_ASSERT_EQUAL(1, peaks[0]);
+    TEST_ASSERT_EQUAL(3, peaks[1]);
+}
+
+void test_peaks_monotone_no_peaks(void)
+{
+    numx_real_t x[] = {1.0f,2.0f,3.0f,4.0f,5.0f};
+    numx_size_t peaks[5], npeaks;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_signal_peaks(x, 5, peaks, 5, &npeaks));
+    TEST_ASSERT_EQUAL(0, npeaks);
+}
+
+void test_peaks_short_signal_no_peaks(void)
+{
+    numx_real_t x[] = {5.0f,5.0f};
+    numx_size_t peaks[2], npeaks;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_signal_peaks(x, 2, peaks, 2, &npeaks));
+    TEST_ASSERT_EQUAL(0, npeaks);
+}
+
+void test_peaks_buffer_too_small(void)
+{
+    numx_real_t x[] = {0.0f,1.0f,0.0f,2.0f,0.0f};
+    numx_size_t peaks[1], npeaks;
+    TEST_ASSERT_EQUAL(NUMX_ERR_BUFFER_SMALL, numx_signal_peaks(x, 5, peaks, 1, &npeaks));
+}
+
+void test_ema_alpha1_copies_input(void)
+{
+    numx_real_t x[] = {1.0f,2.0f,3.0f}, out[3];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_signal_ema(x, 3, 1.0f, out));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 1.0f, out[0]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 2.0f, out[1]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 3.0f, out[2]);
+}
+
+void test_ema_alpha0_stays_at_first(void)
+{
+    numx_real_t x[] = {5.0f,1.0f,1.0f,1.0f}, out[4];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_signal_ema(x, 4, 0.0f, out));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 5.0f, out[0]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 5.0f, out[1]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 5.0f, out[2]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 5.0f, out[3]);
+}
+
+void test_ema_known_sequence(void)
+{
+    numx_real_t x[] = {0.0f,1.0f,0.0f,0.0f}, out[4];
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_signal_ema(x, 4, 0.5f, out));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 0.0f,   out[0]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 0.5f,   out[1]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 0.25f,  out[2]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 0.125f, out[3]);
+}
+
+void test_ema_invalid_alpha_returns_error(void)
+{
+    numx_real_t x[2]={0}, out[2];
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_signal_ema(x, 2, -0.1f, out));
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_signal_ema(x, 2,  1.1f, out));
+}
+
+void numx_test_signal(void)
+{
+    RUN_TEST(test_window_rect_all_ones);
+    RUN_TEST(test_window_rect_n1);
+    RUN_TEST(test_window_hann_endpoints_zero);
+    RUN_TEST(test_window_hann_midpoint_one);
+    RUN_TEST(test_window_hann_n1_returns_one);
+    RUN_TEST(test_window_hamming_endpoints);
+    RUN_TEST(test_window_hamming_midpoint_one);
+    RUN_TEST(test_window_blackman_endpoints_zero);
+    RUN_TEST(test_window_blackman_midpoint_one);
+    RUN_TEST(test_convolve_box);
+    RUN_TEST(test_convolve_unit_impulse);
+    RUN_TEST(test_convolve_null_returns_error);
+    RUN_TEST(test_correlate_autocorr_peak_at_lag0);
+    RUN_TEST(test_correlate_output_length);
+    RUN_TEST(test_fir_identity_tap);
+    RUN_TEST(test_fir_moving_average);
+    RUN_TEST(test_fir_null_returns_error);
+    RUN_TEST(test_iir_biquad_identity);
+    RUN_TEST(test_iir_biquad_scale);
+    RUN_TEST(test_iir_biquad_null_returns_error);
+    RUN_TEST(test_peaks_two_peaks);
+    RUN_TEST(test_peaks_monotone_no_peaks);
+    RUN_TEST(test_peaks_short_signal_no_peaks);
+    RUN_TEST(test_peaks_buffer_too_small);
+    RUN_TEST(test_ema_alpha1_copies_input);
+    RUN_TEST(test_ema_alpha0_stays_at_first);
+    RUN_TEST(test_ema_known_sequence);
+    RUN_TEST(test_ema_invalid_alpha_returns_error);
+}

--- a/tests/x86/test_sketch.c
+++ b/tests/x86/test_sketch.c
@@ -1,0 +1,112 @@
+/**
+ * @file test_sketch.c
+ * @brief Randomized SVD tests — float32 / x86 host build.
+ *        numx_real_t = float  (NUMX_USE_DOUBLE not set)
+ *
+ * Correctness is verified by Frobenius reconstruction error and singular
+ * value accuracy. Tolerances are loose because rSVD is a randomized algorithm.
+ */
+
+#include "unity.h"
+#include "numx/sketch.h"
+
+#define TOL_RECON 0.5f
+#define TOL_SV    0.2f
+
+static numx_real_t recon_err_sq(
+    const numx_real_t *A,
+    const numx_real_t *U, const numx_real_t *S, const numx_real_t *Vt,
+    numx_size_t m, numx_size_t n, numx_size_t rank)
+{
+    numx_size_t i, j, k;
+    numx_real_t val, diff, err = (numx_real_t)0.0;
+    for (i = 0; i < m; i++)
+        for (j = 0; j < n; j++)
+        {
+            val = (numx_real_t)0.0;
+            for (k = 0; k < rank; k++)
+                val += U[i*rank+k]*S[k]*Vt[k*n+j];
+            diff = A[i*n+j]-val;
+            err += diff*diff;
+        }
+    return err;
+}
+
+void test_rsvd_rank1_reconstruction(void)
+{
+    numx_real_t A[6]  = {4.0f,0.0f, 0.0f,0.0f, 0.0f,0.0f};
+    numx_real_t U[3]  = {0};
+    numx_real_t S[1]  = {0};
+    numx_real_t Vt[2] = {0};
+    TEST_ASSERT_EQUAL(NUMX_OK,
+        numx_sketch_rsvd(A, 3, 2, 1, 1, 42u, U, S, Vt));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_SV, 4.0f, S[0]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_RECON, 0.0f,
+        recon_err_sq(A, U, S, Vt, 3, 2, 1));
+}
+
+void test_rsvd_diagonal_rank2(void)
+{
+    numx_real_t A[16] = {
+        3.0f,0.0f,0.0f,0.0f,
+        0.0f,2.0f,0.0f,0.0f,
+        0.0f,0.0f,0.0f,0.0f,
+        0.0f,0.0f,0.0f,0.0f
+    };
+    numx_real_t U[8]  = {0};
+    numx_real_t S[2]  = {0};
+    numx_real_t Vt[8] = {0};
+    TEST_ASSERT_EQUAL(NUMX_OK,
+        numx_sketch_rsvd(A, 4, 4, 2, 2, 42u, U, S, Vt));
+    TEST_ASSERT_TRUE(S[0] >= S[1]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_SV, 3.0f, S[0]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_SV, 2.0f, S[1]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_RECON, 0.0f,
+        recon_err_sq(A, U, S, Vt, 4, 4, 2));
+}
+
+void test_rsvd_tall_matrix(void)
+{
+    numx_real_t A[6]  = {1,0, 1,0, 1,0};
+    numx_real_t U[3]  = {0};
+    numx_real_t S[1]  = {0};
+    numx_real_t Vt[2] = {0};
+    TEST_ASSERT_EQUAL(NUMX_OK,
+        numx_sketch_rsvd(A, 3, 2, 1, 1, 7u, U, S, Vt));
+    TEST_ASSERT_FLOAT_WITHIN(TOL_SV, 1.732f, S[0]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL_RECON, 0.0f,
+        recon_err_sq(A, U, S, Vt, 3, 2, 1));
+}
+
+void test_rsvd_null_returns_error(void)
+{
+    numx_real_t A[4]={0},U[2]={0},S[1]={0},Vt[2]={0};
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+        numx_sketch_rsvd(NULL,2,2,1,1,1u,U,S,Vt));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+        numx_sketch_rsvd(A,2,2,1,1,1u,NULL,S,Vt));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+        numx_sketch_rsvd(A,2,2,1,1,1u,U,NULL,Vt));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+        numx_sketch_rsvd(A,2,2,1,1,1u,U,S,NULL));
+}
+
+void test_rsvd_invalid_arg_returns_error(void)
+{
+    numx_real_t A[4]={0},U[2]={0},S[1]={0},Vt[2]={0};
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+        numx_sketch_rsvd(A,2,2,0,1,1u,U,S,Vt));
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+        numx_sketch_rsvd(A,0,2,1,1,1u,U,S,Vt));
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+        numx_sketch_rsvd(A,2,2,NUMX_MAX_SKETCH_RANK,1,1u,U,S,Vt));
+}
+
+void numx_test_sketch(void)
+{
+    RUN_TEST(test_rsvd_rank1_reconstruction);
+    RUN_TEST(test_rsvd_diagonal_rank2);
+    RUN_TEST(test_rsvd_tall_matrix);
+    RUN_TEST(test_rsvd_null_returns_error);
+    RUN_TEST(test_rsvd_invalid_arg_returns_error);
+}

--- a/tests/x86/test_stats.c
+++ b/tests/x86/test_stats.c
@@ -1,0 +1,246 @@
+/**
+ * @file test_stats.c
+ * @brief Statistics tests — float32 / x86 host build.
+ *        numx_real_t = float  (NUMX_USE_DOUBLE not set)
+ */
+
+#include "unity.h"
+#include "numx/numx_types.h"
+#include "numx/stats.h"
+
+#define TOL 1e-4f
+
+void test_stats_mean_known(void)
+{
+    numx_real_t a[] = {1.0f,2.0f,3.0f,4.0f,5.0f};
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_stats_mean(a, 5, &r));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 3.0f, r);
+}
+
+void test_stats_mean_negative_values(void)
+{
+    numx_real_t a[] = {-3.0f,-1.0f,1.0f,3.0f};
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_stats_mean(a, 4, &r));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 0.0f, r);
+}
+
+void test_stats_mean_arithmetic_sequence(void)
+{
+    numx_real_t a[] = {1.0f,2.0f,3.0f,4.0f,5.0f,6.0f,7.0f};
+    numx_real_t r;
+    numx_stats_mean(a, 7, &r);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 4.0f, r);
+}
+
+void test_stats_mean_constant_array(void)
+{
+    numx_real_t a[] = {5.0f,5.0f,5.0f,5.0f};
+    numx_real_t r;
+    numx_stats_mean(a, 4, &r);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 5.0f, r);
+}
+
+void test_stats_mean_single_element(void)
+{
+    numx_real_t a[] = {42.0f};
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_stats_mean(a, 1, &r));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 42.0f, r);
+}
+
+void test_stats_mean_null_a(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_stats_mean(NULL, 3, &r));
+}
+
+void test_stats_mean_null_result(void)
+{
+    numx_real_t a[] = {1.0f,2.0f};
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_stats_mean(a, 2, NULL));
+}
+
+void test_stats_mean_n_zero(void)
+{
+    numx_real_t a[] = {1.0f}, r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_stats_mean(a, 0, &r));
+}
+
+void test_stats_variance_pop_known(void)
+{
+    numx_real_t a[] = {2.0f,4.0f,4.0f,4.0f,5.0f,5.0f,7.0f,9.0f};
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_stats_variance(a, 8, NUMX_VAR_POPULATION, &r));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 4.0f, r);
+}
+
+void test_stats_variance_sample_known(void)
+{
+    numx_real_t a[] = {2.0f,4.0f,4.0f,4.0f,5.0f,5.0f,7.0f,9.0f};
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_stats_variance(a, 8, NUMX_VAR_SAMPLE, &r));
+    TEST_ASSERT_FLOAT_WITHIN(1e-3f, 32.0f/7.0f, r);
+}
+
+void test_stats_variance_constant_is_zero(void)
+{
+    numx_real_t a[] = {7.0f,7.0f,7.0f,7.0f};
+    numx_real_t r;
+    numx_stats_variance(a, 4, NUMX_VAR_POPULATION, &r);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 0.0f, r);
+}
+
+void test_stats_variance_sample_ge_population(void)
+{
+    numx_real_t a[] = {1.0f,2.0f,3.0f,4.0f,5.0f};
+    numx_real_t rpop, rsamp;
+    numx_stats_variance(a, 5, NUMX_VAR_POPULATION, &rpop);
+    numx_stats_variance(a, 5, NUMX_VAR_SAMPLE, &rsamp);
+    TEST_ASSERT_TRUE(rsamp > rpop);
+}
+
+void test_stats_variance_sample_n1_rejected(void)
+{
+    numx_real_t a[] = {1.0f}, r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG,
+                      numx_stats_variance(a, 1, NUMX_VAR_SAMPLE, &r));
+}
+
+void test_stats_variance_null(void)
+{
+    numx_real_t a[] = {1.0f,2.0f}, r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_stats_variance(NULL, 2, NUMX_VAR_POPULATION, &r));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR,
+                      numx_stats_variance(a, 2, NUMX_VAR_POPULATION, NULL));
+}
+
+void test_stats_median_odd_known(void)
+{
+    numx_real_t a[] = {5.0f,3.0f,1.0f,4.0f,2.0f};
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_stats_median(a, 5, &r));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 3.0f, r);
+}
+
+void test_stats_median_even_known(void)
+{
+    numx_real_t a[] = {4.0f,1.0f,3.0f,2.0f};
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_stats_median(a, 4, &r));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 2.5f, r);
+}
+
+void test_stats_median_sorted_middle(void)
+{
+    numx_real_t a[] = {10.0f,20.0f,30.0f,40.0f,50.0f};
+    numx_real_t r;
+    numx_stats_median(a, 5, &r);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 30.0f, r);
+}
+
+void test_stats_median_does_not_modify_input(void)
+{
+    numx_real_t a[] = {5.0f,3.0f,1.0f};
+    numx_real_t r;
+    numx_stats_median(a, 3, &r);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 5.0f, a[0]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 3.0f, a[1]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 1.0f, a[2]);
+}
+
+void test_stats_median_single_element(void)
+{
+    numx_real_t a[] = {7.0f};
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_stats_median(a, 1, &r));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 7.0f, r);
+}
+
+void test_stats_median_two_elements(void)
+{
+    numx_real_t a[] = {3.0f,1.0f};
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_stats_median(a, 2, &r));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 2.0f, r);
+}
+
+void test_stats_median_null(void)
+{
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_stats_median(NULL, 3, &r));
+    numx_real_t a[] = {1.0f};
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_stats_median(a, 1, NULL));
+}
+
+void test_stats_percentile_0_is_min(void)
+{
+    numx_real_t a[] = {5.0f,3.0f,1.0f,4.0f,2.0f};
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_stats_percentile(a, 5, 0.0f, &r));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 1.0f, r);
+}
+
+void test_stats_percentile_100_is_max(void)
+{
+    numx_real_t a[] = {5.0f,3.0f,1.0f,4.0f,2.0f};
+    numx_real_t r;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_stats_percentile(a, 5, 100.0f, &r));
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 5.0f, r);
+}
+
+void test_stats_percentile_does_not_modify_input(void)
+{
+    numx_real_t a[] = {3.0f,1.0f,2.0f};
+    numx_real_t r;
+    numx_stats_percentile(a, 3, 50.0f, &r);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 3.0f, a[0]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 1.0f, a[1]);
+    TEST_ASSERT_FLOAT_WITHIN(TOL, 2.0f, a[2]);
+}
+
+void test_stats_percentile_null(void)
+{
+    numx_real_t a[] = {1.0f,2.0f}, r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_stats_percentile(NULL, 2, 50.0f, &r));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_stats_percentile(a, 2, 50.0f, NULL));
+}
+
+void test_stats_percentile_out_of_range(void)
+{
+    numx_real_t a[] = {1.0f,2.0f,3.0f}, r;
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_stats_percentile(a, 3, -1.0f, &r));
+    TEST_ASSERT_EQUAL(NUMX_ERR_INVALID_ARG, numx_stats_percentile(a, 3, 101.0f, &r));
+}
+
+void numx_test_stats(void)
+{
+    RUN_TEST(test_stats_mean_known);
+    RUN_TEST(test_stats_mean_negative_values);
+    RUN_TEST(test_stats_mean_arithmetic_sequence);
+    RUN_TEST(test_stats_mean_constant_array);
+    RUN_TEST(test_stats_mean_single_element);
+    RUN_TEST(test_stats_mean_null_a);
+    RUN_TEST(test_stats_mean_null_result);
+    RUN_TEST(test_stats_mean_n_zero);
+    RUN_TEST(test_stats_variance_pop_known);
+    RUN_TEST(test_stats_variance_sample_known);
+    RUN_TEST(test_stats_variance_constant_is_zero);
+    RUN_TEST(test_stats_variance_sample_ge_population);
+    RUN_TEST(test_stats_variance_sample_n1_rejected);
+    RUN_TEST(test_stats_variance_null);
+    RUN_TEST(test_stats_median_odd_known);
+    RUN_TEST(test_stats_median_even_known);
+    RUN_TEST(test_stats_median_sorted_middle);
+    RUN_TEST(test_stats_median_does_not_modify_input);
+    RUN_TEST(test_stats_median_single_element);
+    RUN_TEST(test_stats_median_two_elements);
+    RUN_TEST(test_stats_median_null);
+    RUN_TEST(test_stats_percentile_0_is_min);
+    RUN_TEST(test_stats_percentile_100_is_max);
+    RUN_TEST(test_stats_percentile_does_not_modify_input);
+    RUN_TEST(test_stats_percentile_null);
+    RUN_TEST(test_stats_percentile_out_of_range);
+}


### PR DESCRIPTION
- Implement root-finding tests in test_roots.c, covering bisection, Newton's method, and Brent's method.
- Create a master test runner in test_runner.c to execute all tests for the x86 float32 build.
- Add signal processing tests in test_signal.c, including window functions, convolution, and FIR/IIR filters.
- Introduce randomized SVD tests in test_sketch.c, verifying reconstruction error and singular value accuracy.
- Implement statistics tests in test_stats.c, covering mean, variance, median, and percentile calculations.
