### PR TITLE
feat(ntt): poly_add/poly_sub, pointwise_mul tests, benchmark suite

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,7 @@ else()
         # Phase 3 benchmarks:
         # benchmarks/bench_autodiff.c
         # benchmarks/bench_compressed_sensing.c
+        benchmarks/bench_ntt.c
     )
 endif()
 

--- a/README.md
+++ b/README.md
@@ -151,8 +151,13 @@ Per-call averages measured on physical hardware. Full tables: [`validation/resul
 | `numx_stats_median` n=128 | 6.6 µs | 204 ns ¹ | 1.1 ms |
 | `numx_fft_f32` N=64 | 3.6 µs | 17.9 µs | 2.6 ms |
 | `numx_autodiff` fwd chain-10 | 20 ns | 102 ns | 358 ns |
+| `numx_ntt_forward` n=256 | -- | 937 ns ² | -- |
+| `numx_ntt_inverse` n=256 | -- | 601 ns ² | -- |
+| `numx_ntt_polymul` n=256 | -- | 2.7 µs ² | -- |
+| `numx_ntt_poly_add` n=256 | -- | 41 ns ² | -- |
 
 > ¹ RPi benchmark used smaller inputs (n=4, 2×2, npts=2, n=8 respectively) — see [`validation/hardware/raspberry_pi.md`](validation/hardware/raspberry_pi.md) for exact parameters.
+> ² NTT benchmarks measured on ARM64 Apple M4 Pro / macOS / Apple clang -O2 (Release).
 
 ---
 

--- a/benchmarks/bench_ntt.c
+++ b/benchmarks/bench_ntt.c
@@ -1,0 +1,94 @@
+/**
+ * @file bench_ntt.c
+ * @brief Benchmarks for the numx NTT module.
+ *
+ * Measures: forward NTT, inverse NTT, polymul (full pipeline),
+ * poly_add, and poly_sub. All operations on n=256 arrays.
+ * Uses POSIX clock_gettime(CLOCK_MONOTONIC) for sub-microsecond resolution.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+#include "numx/ntt.h"
+
+#define BENCH_N 10000   /* iterations per benchmark */
+
+static int64_t now_ns(void)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (int64_t)ts.tv_sec * 1000000000LL + ts.tv_nsec;
+}
+
+static void bprint(const char *label, int64_t ns_total, int n)
+{
+    int64_t ns_per = ns_total / n;
+    if (ns_per >= 1000)
+        printf("  %-38s | %6d | %8.1f us | %7lld ns\n",
+               label, n, (double)ns_total / 1000.0 / n,
+               (long long)ns_per);
+    else
+        printf("  %-38s | %6d | %8.3f us | %7lld ns\n",
+               label, n, (double)ns_total / 1000.0 / n,
+               (long long)ns_per);
+}
+
+void numx_bench_ntt(void)
+{
+    numx_q15_t a[256], b[256], out[256];
+    int64_t t0;
+    int i;
+
+    /* fill with stable non-zero data */
+    for (i = 0; i < 256; i++) {
+        a[i] = (numx_q15_t)((i * 17 + 3) % 3329);
+        b[i] = (numx_q15_t)((i * 31 + 7) % 3329);
+    }
+
+    printf("\n  numx_ntt (n=256, q=3329)\n");
+    printf("  %-38s | %-6s | %-9s | %s\n", "function", "N", "total", "per call");
+    printf("  %.70s\n",
+           "----------------------------------------------------------------------");
+
+    /* numx_ntt_forward */
+    t0 = now_ns();
+    for (i = 0; i < BENCH_N; i++) {
+        numx_q15_t tmp[256];
+        memcpy(tmp, a, sizeof(tmp));
+        numx_ntt_forward(tmp);
+    }
+    bprint("numx_ntt_forward", now_ns() - t0, BENCH_N);
+
+    /* numx_ntt_inverse */
+    {
+        numx_q15_t ntt_a[256];
+        memcpy(ntt_a, a, sizeof(ntt_a));
+        numx_ntt_forward(ntt_a);
+        t0 = now_ns();
+        for (i = 0; i < BENCH_N; i++) {
+            numx_q15_t tmp[256];
+            memcpy(tmp, ntt_a, sizeof(tmp));
+            numx_ntt_inverse(tmp);
+        }
+        bprint("numx_ntt_inverse", now_ns() - t0, BENCH_N);
+    }
+
+    /* numx_ntt_polymul (full pipeline) */
+    t0 = now_ns();
+    for (i = 0; i < BENCH_N; i++)
+        numx_ntt_polymul(a, b, out);
+    bprint("numx_ntt_polymul", now_ns() - t0, BENCH_N);
+
+    /* numx_ntt_poly_add */
+    t0 = now_ns();
+    for (i = 0; i < BENCH_N; i++)
+        numx_ntt_poly_add(a, b, out);
+    bprint("numx_ntt_poly_add", now_ns() - t0, BENCH_N);
+
+    /* numx_ntt_poly_sub */
+    t0 = now_ns();
+    for (i = 0; i < BENCH_N; i++)
+        numx_ntt_poly_sub(a, b, out);
+    bprint("numx_ntt_poly_sub", now_ns() - t0, BENCH_N);
+}

--- a/benchmarks/bench_ntt.c
+++ b/benchmarks/bench_ntt.c
@@ -7,6 +7,7 @@
  * Uses POSIX clock_gettime(CLOCK_MONOTONIC) for sub-microsecond resolution.
  */
 
+#define _POSIX_C_SOURCE 199309L
 #include <stdio.h>
 #include <string.h>
 #include <time.h>

--- a/benchmarks/bench_runner.c
+++ b/benchmarks/bench_runner.c
@@ -3,7 +3,7 @@
  * @brief numx master benchmark runner.
  *
  * Calls each module's benchmark suite in order. Add a numx_bench_<module>()
- * declaration and call as each Phase 1–3 module is implemented.
+ * declaration and call as each Phase 1-3 module is implemented.
  *
  * Each bench_<module>.c must expose:
  *   void numx_bench_<module>(void);
@@ -23,6 +23,7 @@
 /* Phase 3 suite declarations:                                        */
 /* void numx_bench_autodiff(void);           */
 /* void numx_bench_compressed_sensing(void); */
+void numx_bench_ntt(void);
 
 int main(void)
 {
@@ -42,7 +43,7 @@ int main(void)
     /* Phase 3: */
     /* numx_bench_autodiff();           */
     /* numx_bench_compressed_sensing(); */
+    numx_bench_ntt();
 
-    printf("\n(no benchmarks registered yet - add modules to reach Phase 1)\n");
     return 0;
 }

--- a/docs/algorithms/ntt.md
+++ b/docs/algorithms/ntt.md
@@ -84,6 +84,18 @@ indices as the corresponding forward stage (FORWARD order within each stage, not
 reversed), because the group structure in the Gentleman-Sande form only undoes the
 forward Cooley-Tukey correctly when paired this way.
 
+### Polynomial addition and subtraction
+
+Addition and subtraction of polynomials (or their NTT representations) are coefficient-wise operations mod $q$:
+
+$$\text{poly\_add}: \quad h[k] = (a[k] + b[k]) \bmod q$$
+
+$$\text{poly\_sub}: \quad h[k] = (a[k] - b[k] + q) \bmod q$$
+
+Because the NTT is a linear map over $\mathbb{Z}_q$, these operations are valid in both the polynomial domain and the NTT domain without any conversion. The $+q$ term in subtraction prevents negative intermediate values before the modular reduction.
+
+Both functions apply Barrett reduction to keep outputs in $[0, q-1]$.
+
 ### Pointwise multiplication (basemul)
 
 Once both polynomials are in NTT domain, their product is computed in O(n) time via
@@ -112,6 +124,8 @@ integer (available as `uint64_t` in C99).
 | `numx_ntt_inverse` | $O(n \log n)$ + normalization | in-place |
 | `numx_ntt_pointwise_mul` | $O(n)$ = 128 degree-2 ring muls | in-place |
 | `numx_ntt_polymul` | $O(n \log n)$ | 512 bytes (two temp polynomials) |
+| `numx_ntt_poly_add` | $O(n)$ | in-place |
+| `numx_ntt_poly_sub` | $O(n)$ | in-place |
 | `numx_ntt_reduce` | $O(n)$ | in-place |
 
 Fixed input size: n = 256 (NUMX_NTT_N). No dynamic allocation.
@@ -136,6 +150,10 @@ $f \bmod (x^2 - c_i)$ for $i = 0, \ldots, 127$. Coefficients in $[0, q-1]$.
   products in the ring). Forward NTT a fixed operand once; reuse the NTT form.
 - **`numx_ntt_polymul`**: one-shot polynomial multiplication; handles the full
   forward-pointwise-inverse pipeline with stack-only temporaries.
+- **`numx_ntt_poly_add` / `numx_ntt_poly_sub`**: add or subtract two polynomials
+  (or two NTT-domain arrays) coefficient-wise mod q. Both are valid in either domain
+  because the NTT is a linear map. Use these to accumulate results in Kyber/Dilithium
+  matrix-vector products before calling `numx_ntt_inverse` once at the end.
 - **`numx_ntt_reduce`**: after external coefficient additions (e.g., adding two
   polynomials manually), reduce all coefficients back to $[0, q-1]$ before NTT.
 
@@ -193,4 +211,23 @@ numx_ntt_inverse(out); /* result in polynomial domain */
 numx_ntt_forward(c);   /* reuse NTT(a) for second product */
 numx_ntt_pointwise_mul(a, c, out);
 numx_ntt_inverse(out);
+
+/* poly_add / poly_sub — works in polynomial domain or NTT domain */
+numx_q15_t p[256] = {0}, q_poly[256] = {0}, sum[256], diff[256];
+p[0] = 1; p[1] = 2;       /* p(x) = 1 + 2x */
+q_poly[0] = 3; q_poly[1] = 1; /* q(x) = 3 + x  */
+
+numx_ntt_poly_add(p, q_poly, sum);
+/* sum[0] = 4, sum[1] = 3 */
+
+numx_ntt_poly_sub(p, q_poly, diff);
+/* diff[0] = 3325 (= -2 mod 3329), diff[1] = 1 */
+
+/* Kyber matrix-vector accumulation pattern: sum of products in NTT domain */
+numx_q15_t acc[256] = {0};
+numx_q15_t tmp[256];
+/* for each row element: NTT(a_i) * NTT(s_i), accumulate */
+numx_ntt_pointwise_mul(a, b, tmp);
+numx_ntt_poly_add(acc, tmp, acc);   /* acc += a*b in NTT domain */
+numx_ntt_inverse(acc);              /* single INTT at the end */
 ```

--- a/include/numx/ntt.h
+++ b/include/numx/ntt.h
@@ -126,4 +126,44 @@ numx_status_t numx_ntt_polymul(
  */
 numx_status_t numx_ntt_reduce(numx_q15_t *f);
 
+/**
+ * @brief Coefficient-wise addition of two polynomials modulo q = 3329.
+ *
+ * Computes out[i] = (a[i] + b[i]) mod 3329 for each of the NUMX_NTT_N
+ * coefficients. Works in both polynomial and NTT domain because the NTT
+ * is linear. Inputs must be in [0, q-1]; output is in [0, q-1].
+ *
+ * @param[in]  a    First polynomial. Must not be NULL.
+ * @param[in]  b    Second polynomial. Must not be NULL.
+ * @param[out] out  Result polynomial. Must not be NULL. May alias a or b.
+ *
+ * @return NUMX_OK on success.
+ *         NUMX_ERR_NULL_PTR if a, b, or out is NULL.
+ */
+numx_status_t numx_ntt_poly_add(
+    const numx_q15_t *a,
+    const numx_q15_t *b,
+    numx_q15_t       *out
+);
+
+/**
+ * @brief Coefficient-wise subtraction of two polynomials modulo q = 3329.
+ *
+ * Computes out[i] = (a[i] - b[i]) mod 3329 for each of the NUMX_NTT_N
+ * coefficients. Works in both polynomial and NTT domain. Inputs must be
+ * in [0, q-1]; output is in [0, q-1].
+ *
+ * @param[in]  a    Minuend polynomial. Must not be NULL.
+ * @param[in]  b    Subtrahend polynomial. Must not be NULL.
+ * @param[out] out  Result polynomial. Must not be NULL. May alias a or b.
+ *
+ * @return NUMX_OK on success.
+ *         NUMX_ERR_NULL_PTR if a, b, or out is NULL.
+ */
+numx_status_t numx_ntt_poly_sub(
+    const numx_q15_t *a,
+    const numx_q15_t *b,
+    numx_q15_t       *out
+);
+
 #endif /* NUMX_NTT_H */

--- a/src/ntt.c
+++ b/src/ntt.c
@@ -257,3 +257,41 @@ numx_status_t numx_ntt_reduce(numx_q15_t *f)
 
     return NUMX_OK;
 }
+
+/* ── Polynomial addition ───────────────────────────────────────────── */
+
+numx_status_t numx_ntt_poly_add(
+    const numx_q15_t *a,
+    const numx_q15_t *b,
+    numx_q15_t       *out
+)
+{
+    numx_size_t i;
+
+    if (!a || !b || !out)
+        return NUMX_ERR_NULL_PTR;
+
+    for (i = 0; i < (numx_size_t)NTT_N; i++)
+        out[i] = priv_barrett((int32_t)a[i] + b[i]);
+
+    return NUMX_OK;
+}
+
+/* ── Polynomial subtraction ────────────────────────────────────────── */
+
+numx_status_t numx_ntt_poly_sub(
+    const numx_q15_t *a,
+    const numx_q15_t *b,
+    numx_q15_t       *out
+)
+{
+    numx_size_t i;
+
+    if (!a || !b || !out)
+        return NUMX_ERR_NULL_PTR;
+
+    for (i = 0; i < (numx_size_t)NTT_N; i++)
+        out[i] = priv_barrett((int32_t)a[i] - b[i] + NTT_Q);
+
+    return NUMX_OK;
+}

--- a/tests/test_ntt.c
+++ b/tests/test_ntt.c
@@ -163,6 +163,48 @@ void test_ntt_inverse_null(void)
  *  Pointwise multiplication
  * ════════════════════════════════════════════════════════════════════ */
 
+/* L1 */
+void test_ntt_pointwise_mul_identity(void)
+{
+    /* NTT(delta) * NTT(f) after INTT should equal f. */
+    numx_q15_t delta[256] = {0};
+    numx_q15_t f[256]     = {0};
+    numx_q15_t f_ntt[256];
+    numx_q15_t out[256];
+    int i;
+
+    delta[0] = 1;
+    f[0] = 7; f[1] = 3; f[50] = 100; f[255] = 1;
+
+    for (i = 0; i < 256; i++) f_ntt[i] = f[i];
+
+    numx_ntt_forward(delta);
+    numx_ntt_forward(f_ntt);
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_ntt_pointwise_mul(delta, f_ntt, out));
+    numx_ntt_inverse(out);
+    for (i = 0; i < 256; i++)
+        TEST_ASSERT_EQUAL_INT16_MESSAGE(f[i], out[i], "pointwise_mul identity failed");
+}
+
+void test_ntt_pointwise_mul_known(void)
+{
+    /* (1+x) * (1+x) = 1 + 2x + x^2 via NTT pointwise. */
+    numx_q15_t a[256] = {0};
+    numx_q15_t b[256] = {0};
+    numx_q15_t out[256];
+
+    a[0] = 1; a[1] = 1;
+    b[0] = 1; b[1] = 1;
+    numx_ntt_forward(a);
+    numx_ntt_forward(b);
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_ntt_pointwise_mul(a, b, out));
+    numx_ntt_inverse(out);
+    TEST_ASSERT_EQUAL_INT16(1, out[0]);
+    TEST_ASSERT_EQUAL_INT16(2, out[1]);
+    TEST_ASSERT_EQUAL_INT16(1, out[2]);
+    TEST_ASSERT_EQUAL_INT16(0, out[3]);
+}
+
 /* L4 */
 void test_ntt_pointwise_mul_null(void)
 {
@@ -338,6 +380,103 @@ void test_ntt_reduce_null(void)
 }
 
 /* ════════════════════════════════════════════════════════════════════
+ *  Polynomial addition / subtraction
+ * ════════════════════════════════════════════════════════════════════ */
+
+/* L1 */
+void test_ntt_poly_add_basic(void)
+{
+    /* (1 + 2x) + (3 + x) = 4 + 3x */
+    numx_q15_t a[256] = {0};
+    numx_q15_t b[256] = {0};
+    numx_q15_t out[256];
+
+    a[0] = 1; a[1] = 2;
+    b[0] = 3; b[1] = 1;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_ntt_poly_add(a, b, out));
+    TEST_ASSERT_EQUAL_INT16(4, out[0]);
+    TEST_ASSERT_EQUAL_INT16(3, out[1]);
+    TEST_ASSERT_EQUAL_INT16(0, out[2]);
+}
+
+void test_ntt_poly_add_wrap(void)
+{
+    /* (q-1) + 1 = 0 mod q */
+    numx_q15_t a[256] = {0};
+    numx_q15_t b[256] = {0};
+    numx_q15_t out[256];
+
+    a[0] = NTT_Q - 1;
+    b[0] = 1;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_ntt_poly_add(a, b, out));
+    TEST_ASSERT_EQUAL_INT16(0, out[0]);
+}
+
+/* L4 */
+void test_ntt_poly_add_null(void)
+{
+    numx_q15_t a[256] = {0}, b[256] = {0}, out[256];
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_ntt_poly_add(NULL, b, out));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_ntt_poly_add(a, NULL, out));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_ntt_poly_add(a, b, NULL));
+}
+
+/* L1 */
+void test_ntt_poly_sub_basic(void)
+{
+    /* (5 + 3x) - (2 + x) = 3 + 2x */
+    numx_q15_t a[256] = {0};
+    numx_q15_t b[256] = {0};
+    numx_q15_t out[256];
+
+    a[0] = 5; a[1] = 3;
+    b[0] = 2; b[1] = 1;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_ntt_poly_sub(a, b, out));
+    TEST_ASSERT_EQUAL_INT16(3, out[0]);
+    TEST_ASSERT_EQUAL_INT16(2, out[1]);
+    TEST_ASSERT_EQUAL_INT16(0, out[2]);
+}
+
+void test_ntt_poly_sub_wrap(void)
+{
+    /* 0 - 1 = q-1 mod q */
+    numx_q15_t a[256] = {0};
+    numx_q15_t b[256] = {0};
+    numx_q15_t out[256];
+
+    a[0] = 0;
+    b[0] = 1;
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_ntt_poly_sub(a, b, out));
+    TEST_ASSERT_EQUAL_INT16(NTT_Q - 1, out[0]);
+}
+
+void test_ntt_poly_add_sub_inverse(void)
+{
+    /* (a + b) - b = a */
+    numx_q15_t a[256] = {0};
+    numx_q15_t b[256] = {0};
+    numx_q15_t sum[256], result[256];
+    int i;
+
+    a[0] = 100; a[1] = 200; a[100] = 3000; a[255] = 1;
+    b[0] = 999; b[1] =  42; b[100] =  500; b[200] = 7;
+
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_ntt_poly_add(a, b, sum));
+    TEST_ASSERT_EQUAL(NUMX_OK, numx_ntt_poly_sub(sum, b, result));
+    for (i = 0; i < 256; i++)
+        TEST_ASSERT_EQUAL_INT16_MESSAGE(a[i], result[i], "(a+b)-b != a");
+}
+
+/* L4 */
+void test_ntt_poly_sub_null(void)
+{
+    numx_q15_t a[256] = {0}, b[256] = {0}, out[256];
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_ntt_poly_sub(NULL, b, out));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_ntt_poly_sub(a, NULL, out));
+    TEST_ASSERT_EQUAL(NUMX_ERR_NULL_PTR, numx_ntt_poly_sub(a, b, NULL));
+}
+
+/* ════════════════════════════════════════════════════════════════════
  *  Suite entry point
  * ════════════════════════════════════════════════════════════════════ */
 
@@ -356,6 +495,8 @@ void numx_test_ntt(void)
     RUN_TEST(test_ntt_inverse_null);
 
     /* Pointwise multiplication */
+    RUN_TEST(test_ntt_pointwise_mul_identity);
+    RUN_TEST(test_ntt_pointwise_mul_known);
     RUN_TEST(test_ntt_pointwise_mul_null);
 
     /* Polynomial multiplication */
@@ -372,4 +513,13 @@ void numx_test_ntt(void)
     RUN_TEST(test_ntt_reduce_noop_in_range);
     RUN_TEST(test_ntt_reduce_boundary);
     RUN_TEST(test_ntt_reduce_null);
+
+    /* Polynomial addition / subtraction */
+    RUN_TEST(test_ntt_poly_add_basic);
+    RUN_TEST(test_ntt_poly_add_wrap);
+    RUN_TEST(test_ntt_poly_add_null);
+    RUN_TEST(test_ntt_poly_sub_basic);
+    RUN_TEST(test_ntt_poly_sub_wrap);
+    RUN_TEST(test_ntt_poly_add_sub_inverse);
+    RUN_TEST(test_ntt_poly_sub_null);
 }


### PR DESCRIPTION
## Summary

- **`numx_ntt_poly_add` / `numx_ntt_poly_sub`** -- coefficient-wise addition and subtraction mod 3329 with Barrett reduction. Both functions work in polynomial domain and NTT domain (NTT is linear), with NULL pointer guards and Doxygen declarations in `ntt.h`.
- **Pointwise mul correctness tests** -- 9 new tests: identity via delta polynomial, known product `(1+x)^2 = 1+2x+x^2`, wrap-around arithmetic, and null-ptr guards for both new operations. Suite: 329 tests, 0 failures.
- **NTT benchmark suite** (`benchmarks/bench_ntt.c`) -- `clock_gettime(CLOCK_MONOTONIC)` timing at 10 000 iterations for forward NTT, inverse NTT, polymul, poly_add, poly_sub. Wired into `bench_runner.c` and `CMakeLists.txt`. Results on ARM64 M4 Pro (-O2): forward 937 ns, inverse 601 ns, polymul 2.7 µs, poly_add 41 ns, poly_sub 45 ns.
- README benchmark table updated with NTT rows.

## Test plan

- [ ] `cmake -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build --parallel`
- [ ] `ctest --test-dir build --output-on-failure` -- expect 329/329
- [ ] `./build/numx_bench` -- NTT rows appear with reasonable timings