### PR TITLE
validation(ntt): finalize NTT validation — M4 Pro results + doc/bench fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,7 @@ Initial public release.
 - `tests/esp32_tests/` — custom test framework for ESP32 (IDF component); per-module test files
 
 **NTT (post-quantum)**
-- `ntt` — negacyclic NTT over Z_3329[x]/(x^256+1) with Kyber/Dilithium parameters; forward NTT, inverse NTT (with normalization), pointwise multiplication (basemul), full polynomial multiplication, and Barrett coefficient reduction; constant-time data path; seven Cooley-Tukey / Gentleman-Sande butterfly stages; precomputed twiddle tables; zero heap allocation; 20 unit tests
+- `ntt` — negacyclic NTT over Z_3329[x]/(x^256+1) with Kyber/Dilithium parameters; forward NTT, inverse NTT (with normalization), pointwise multiplication (basemul), full polynomial multiplication, and Barrett coefficient reduction; constant-time data path; seven Cooley-Tukey / Gentleman-Sande butterfly stages; precomputed twiddle tables; zero heap allocation; 29 unit tests
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -151,13 +151,13 @@ Per-call averages measured on physical hardware. Full tables: [`validation/resul
 | `numx_stats_median` n=128 | 6.6 µs | 204 ns ¹ | 1.1 ms |
 | `numx_fft_f32` N=64 | 3.6 µs | 17.9 µs | 2.6 ms |
 | `numx_autodiff` fwd chain-10 | 20 ns | 102 ns | 358 ns |
-| `numx_ntt_forward` n=256 | -- | 937 ns ² | -- |
-| `numx_ntt_inverse` n=256 | -- | 601 ns ² | -- |
-| `numx_ntt_polymul` n=256 | -- | 2.7 µs ² | -- |
-| `numx_ntt_poly_add` n=256 | -- | 41 ns ² | -- |
+| `numx_ntt_forward` n=256 | 1.9 µs ² | 26.6 µs | 767 µs |
+| `numx_ntt_inverse` n=256 | 1.1 µs ² | 22.0 µs | 673 µs |
+| `numx_ntt_polymul` n=256 | 5.3 µs ² | 81.3 µs | 2.4 ms |
+| `numx_ntt_poly_add` n=256 | 121 ns ² | 2.4 µs | 72.3 µs |
 
 > ¹ RPi benchmark used smaller inputs (n=4, 2×2, npts=2, n=8 respectively) — see [`validation/hardware/raspberry_pi.md`](validation/hardware/raspberry_pi.md) for exact parameters.
-> ² NTT benchmarks measured on ARM64 Apple M4 Pro / macOS / Apple clang -O2 (Release).
+> ² NTT x86-64 column measured on WSL2 Ubuntu 24.04 / gcc 13.3.0 (not the native Ubuntu 22.04 / gcc 11.4 host used for the other rows) — see [`validation/results/ntt/ntt.md`](validation/results/ntt/ntt.md). NTT operates on fixed-point `numx_q15_t`, unaffected by the float32/float64 build flag.
 
 ---
 

--- a/benchmarks/bench_ntt.c
+++ b/benchmarks/bench_ntt.c
@@ -27,11 +27,11 @@ static void bprint(const char *label, int64_t ns_total, int n)
     int64_t ns_per = ns_total / n;
     if (ns_per >= 1000)
         printf("  %-38s | %6d | %8.1f us | %7lld ns\n",
-               label, n, (double)ns_total / 1000.0 / n,
+               label, n, (double)ns_total / 1000.0,
                (long long)ns_per);
     else
         printf("  %-38s | %6d | %8.3f us | %7lld ns\n",
-               label, n, (double)ns_total / 1000.0 / n,
+               label, n, (double)ns_total / 1000.0,
                (long long)ns_per);
 }
 

--- a/docs/algorithms/ntt.md
+++ b/docs/algorithms/ntt.md
@@ -1,6 +1,6 @@
 # Number Theoretic Transform
 
-**Module:** `numx/ntt.h` | **Category:** Post-Quantum Cryptography | **Phase:** P3.12
+**Module:** `numx/ntt.h` | **Category:** Post-Quantum Cryptography | **Phase:** P3.04
 
 ---
 

--- a/validation/README.md
+++ b/validation/README.md
@@ -50,8 +50,10 @@ validation/
 │   │   └── autodiff.md        (forward-mode dual numbers, reverse-mode static tape)
 │   ├── compressed_sensing/
 │   │   └── compressed_sensing.md  (OMP, ISTA)
-│   └── sketch/
-│       └── sketch.md          (randomized SVD — Halko-Martinsson-Tropp)
+│   ├── sketch/
+│   │   └── sketch.md          (randomized SVD — Halko-Martinsson-Tropp)
+│   └── ntt/
+│       └── ntt.md             (NTT forward/inverse, pointwise_mul, polymul, poly_add/sub, reduce)
 ├── c/
 │   ├── val_runner.c           ← Phase 1 timing benchmark runner
 │   └── val_bench_phase2.c     ← Phase 2 timing benchmark runner

--- a/validation/hardware/esp32_devkit_v1.md
+++ b/validation/hardware/esp32_devkit_v1.md
@@ -7,6 +7,11 @@
 > **Status: Phase 1 complete ✅ — 243/243 Unity tests passed (2026-05-29).**
 > Per-function timing results are recorded in each module's result file under `validation/results/`.
 > Per-function timing summary table below will be filled in during Phase 2 validation.
+>
+> **NTT (Post-Quantum): 29/29 tests passed (2026-07-03), commit `daf5b9c`, validated by
+> Amir Ab Khoshk.** Built via a standalone example project (`examples/esp32_ntt_test/`),
+> not the `tests/esp32_tests/` harness used above — see
+> [`validation/results/ntt/ntt.md`](../results/ntt/ntt.md) for full detail and caveats.
 
 **Profile date:** 2026-05-25
 **numx commit:** d81b386

--- a/validation/hardware/mac_mini_m4_pro.md
+++ b/validation/hardware/mac_mini_m4_pro.md
@@ -1,7 +1,7 @@
 # Hardware Profile: Mac mini (Apple M4 Pro)
 
-**Profile date:** 2026-06-09 (last validated)
-**numx commit:** 2fc85d0
+**Profile date:** 2026-06-09 (last validated) / 2026-07-03 (NTT addendum)
+**numx commit:** 2fc85d0 (base) / c397429 (NTT)
 **Validator:** Erfan Jazeb Nikoo
 
 ## System
@@ -77,5 +77,13 @@ cmake --build build --parallel
 | spectral_norm (16×32, iter=32) | 100 | 1,403 | 14,030 |
 | omp (16×32, k=4) | 100 | 86 | 860 |
 | ista (16×32, λ=0.1, iter=500) | 100 | 11,144 | 111,440 |
+| **NTT** (added 2026-07-03) | | | |
+| numx_ntt_forward n=256 | 10,000 | 11,171 | 1,117 |
+| numx_ntt_inverse n=256 | 10,000 | 6,607 | 660 |
+| numx_ntt_polymul n=256 | 10,000 | 29,145 | 2,914 |
+| numx_ntt_poly_add n=256 | 10,000 | 485 | 48 |
+| numx_ntt_poly_sub n=256 | 10,000 | 545 | 54 |
 
-**All tests:** 300 / 300 PASS on 2026-06-09 with commit 2fc85d0
+**All tests:** 300 / 300 PASS on 2026-06-09 with commit 2fc85d0; **329 / 329 PASS** (29 new NTT tests)
+on 2026-07-03 with commit c397429. Full per-test breakdown in
+[`validation/results/ntt/ntt.md`](../results/ntt/ntt.md).

--- a/validation/hardware/raspberry_pi.md
+++ b/validation/hardware/raspberry_pi.md
@@ -43,8 +43,12 @@
 |------------------|-------|----------|------------|
 | Phase 1 (linalg, stats, roots, integrate, differentiate, interpolate, poly, ode) | 300 | 0 | 2026-06-13 |
 | Phase 2 (signal, fft, autodiff, compressed_sensing, sketch) | included in 300 | 0 | 2026-06-13 |
+| Phase 3 (ntt) | 29 | 0 | 2026-07-03 |
 
-**300 / 300 Unity tests PASS** on Raspberry Pi 4 / aarch64 / gcc 14.2.0 / float32.
+**300 / 300 Unity tests PASS** on Raspberry Pi 4 / aarch64 / gcc 14.2.0 / float32 (2026-06-13).
+**329 / 329 Unity tests PASS** (29 new NTT tests) as of 2026-07-03, commit `daf5b9c`. Validator:
+Amir Ab Khoshk. Full per-test breakdown in
+[`validation/results/ntt/ntt.md`](../results/ntt/ntt.md).
 
 ## Performance summary
 
@@ -97,3 +101,8 @@
 | cs_spectral_norm 16×32 iter=32    | 100     | 9,676      | 96,769        |
 | cs_omp 16×32 k=4                  | 100     | 644        | 6,443         |
 | cs_ista 16×32 lam=0.1 iter=500    | 100     | 117,119    | 1,171,190     |
+| numx_ntt_forward n=256 (2026-07-03) | 10,000  | 265,890    | 26,589        |
+| numx_ntt_inverse n=256 (2026-07-03) | 10,000  | 219,660    | 21,966        |
+| numx_ntt_polymul n=256 (2026-07-03) | 10,000  | 813,320    | 81,332        |
+| numx_ntt_poly_add n=256 (2026-07-03)| 10,000  | 24,100     | 2,410         |
+| numx_ntt_poly_sub n=256 (2026-07-03)| 10,000  | 27,370     | 2,737         |

--- a/validation/results/ntt/ntt.md
+++ b/validation/results/ntt/ntt.md
@@ -1,0 +1,421 @@
+# Validation: numx_ntt
+
+Covers: `numx_ntt_forward` · `numx_ntt_inverse` · `numx_ntt_pointwise_mul` · `numx_ntt_polymul` · `numx_ntt_poly_add` · `numx_ntt_poly_sub` · `numx_ntt_reduce`
+
+---
+
+## Windows x86 - Windows 11 / MSVC 19.51.36246.0 (VS 2026 Build Tools) / float32
+**Validator:** Amir Ab Khoshk | **Date:** 2026-07-03 | **Commit:** daf5b9c
+
+> Platform note: this run was performed on Windows/MSVC, not Linux x86-64. Raspberry Pi 4
+> and ESP32-S3 validation were not performed in this session, no direct access to that
+> hardware was available.
+>
+> Built with the Win32 CMake generator platform (`-A Win32`), producing a 32-bit
+> Intel i386 binary, confirmed via `file build_x86/Release/numx_tests.exe`.
+> Uses `numx_real_t = float` (no `NUMX_USE_DOUBLE`).
+
+### Test cases
+
+| Test | Result |
+|------|--------|
+| test_ntt_forward_delta | ✅ |
+| test_ntt_forward_zero | ✅ |
+| test_ntt_forward_null | ✅ |
+| test_ntt_inverse_roundtrip_delta | ✅ |
+| test_ntt_inverse_roundtrip_x | ✅ |
+| test_ntt_inverse_roundtrip_x2 | ✅ |
+| test_ntt_inverse_roundtrip_full | ✅ |
+| test_ntt_inverse_null | ✅ |
+| test_ntt_pointwise_mul_identity | ✅ |
+| test_ntt_pointwise_mul_known | ✅ |
+| test_ntt_pointwise_mul_null | ✅ |
+| test_ntt_polymul_delta_identity | ✅ |
+| test_ntt_polymul_x_times_x | ✅ |
+| test_ntt_polymul_wrap_negacyclic | ✅ |
+| test_ntt_polymul_x255_times_x | ✅ |
+| test_ntt_polymul_commutativity | ✅ |
+| test_ntt_polymul_known_linear | ✅ |
+| test_ntt_polymul_random_vs_ref | ✅ |
+| test_ntt_polymul_null | ✅ |
+| test_ntt_reduce_noop_in_range | ✅ |
+| test_ntt_reduce_boundary | ✅ |
+| test_ntt_reduce_null | ✅ |
+| test_ntt_poly_add_basic | ✅ |
+| test_ntt_poly_add_wrap | ✅ |
+| test_ntt_poly_add_null | ✅ |
+| test_ntt_poly_sub_basic | ✅ |
+| test_ntt_poly_sub_wrap | ✅ |
+| test_ntt_poly_add_sub_inverse | ✅ |
+| test_ntt_poly_sub_null | ✅ |
+
+*329 / 329 Unity tests PASS*
+
+### Performance
+
+Not available. `numx_bench` on Windows is built from `benchmarks/bench_win.c`, which does
+not call `numx_bench_ntt()` (that call exists only in `benchmarks/bench_runner.c`, used on
+the POSIX build path). No separate 32-bit bench target was built for this validation.
+
+**RESULTS: 29 PASS / 0 FAIL / 29 TOTAL**
+
+---
+
+## Windows x64 - Windows 11 / MSVC 19.51.36246.0 (VS 2026 Build Tools) / float64
+**Validator:** Amir Ab Khoshk | **Date:** 2026-07-03 | **Commit:** daf5b9c
+
+> Built from the root CMakeLists.txt (which already includes the NTT module) with
+> `CMAKE_C_FLAGS="-DNUMX_USE_DOUBLE -DUNITY_INCLUDE_DOUBLE"` passed on the command line,
+> so `numx_real_t = double` throughout without editing any existing CMake files.
+> Confirmed still a 64-bit x86-64 binary via `file build_x64_f64/Release/numx_tests.exe`.
+
+### Test cases
+
+| Test | Result |
+|------|--------|
+| test_ntt_forward_delta | ✅ |
+| test_ntt_forward_zero | ✅ |
+| test_ntt_forward_null | ✅ |
+| test_ntt_inverse_roundtrip_delta | ✅ |
+| test_ntt_inverse_roundtrip_x | ✅ |
+| test_ntt_inverse_roundtrip_x2 | ✅ |
+| test_ntt_inverse_roundtrip_full | ✅ |
+| test_ntt_inverse_null | ✅ |
+| test_ntt_pointwise_mul_identity | ✅ |
+| test_ntt_pointwise_mul_known | ✅ |
+| test_ntt_pointwise_mul_null | ✅ |
+| test_ntt_polymul_delta_identity | ✅ |
+| test_ntt_polymul_x_times_x | ✅ |
+| test_ntt_polymul_wrap_negacyclic | ✅ |
+| test_ntt_polymul_x255_times_x | ✅ |
+| test_ntt_polymul_commutativity | ✅ |
+| test_ntt_polymul_known_linear | ✅ |
+| test_ntt_polymul_random_vs_ref | ✅ |
+| test_ntt_polymul_null | ✅ |
+| test_ntt_reduce_noop_in_range | ✅ |
+| test_ntt_reduce_boundary | ✅ |
+| test_ntt_reduce_null | ✅ |
+| test_ntt_poly_add_basic | ✅ |
+| test_ntt_poly_add_wrap | ✅ |
+| test_ntt_poly_add_null | ✅ |
+| test_ntt_poly_sub_basic | ✅ |
+| test_ntt_poly_sub_wrap | ✅ |
+| test_ntt_poly_add_sub_inverse | ✅ |
+| test_ntt_poly_sub_null | ✅ |
+
+*329 / 329 Unity tests PASS*
+
+### Performance
+
+Not available. Same `bench_win.c` gap as above; no float64 bench target was built for
+this validation.
+
+**RESULTS: 29 PASS / 0 FAIL / 29 TOTAL**
+
+---
+
+## Linux x86-64 - Ubuntu 24.04.4 LTS (WSL2, kernel 6.6.114.1-microsoft-standard-WSL2) / gcc 13.3.0 / float64
+**Validator:** Amir Ab Khoshk | **Date:** 2026-07-03 | **Commit:** daf5b9c
+
+> Built from the root CMakeLists.txt with `CMAKE_C_FLAGS="-DNUMX_USE_DOUBLE -DUNITY_INCLUDE_DOUBLE"`
+> passed on the command line, no existing CMake files edited. `numx_val_bench_phase2`
+> fails to build under float64 (pre-existing float32-only pointer types in that tool), so
+> only the `numx_tests` and `numx_bench` targets were built, both of which build cleanly.
+
+### Test cases
+
+| Test | Result |
+|------|--------|
+| test_ntt_forward_delta | ✅ |
+| test_ntt_forward_zero | ✅ |
+| test_ntt_forward_null | ✅ |
+| test_ntt_inverse_roundtrip_delta | ✅ |
+| test_ntt_inverse_roundtrip_x | ✅ |
+| test_ntt_inverse_roundtrip_x2 | ✅ |
+| test_ntt_inverse_roundtrip_full | ✅ |
+| test_ntt_inverse_null | ✅ |
+| test_ntt_pointwise_mul_identity | ✅ |
+| test_ntt_pointwise_mul_known | ✅ |
+| test_ntt_pointwise_mul_null | ✅ |
+| test_ntt_polymul_delta_identity | ✅ |
+| test_ntt_polymul_x_times_x | ✅ |
+| test_ntt_polymul_wrap_negacyclic | ✅ |
+| test_ntt_polymul_x255_times_x | ✅ |
+| test_ntt_polymul_commutativity | ✅ |
+| test_ntt_polymul_known_linear | ✅ |
+| test_ntt_polymul_random_vs_ref | ✅ |
+| test_ntt_polymul_null | ✅ |
+| test_ntt_reduce_noop_in_range | ✅ |
+| test_ntt_reduce_boundary | ✅ |
+| test_ntt_reduce_null | ✅ |
+| test_ntt_poly_add_basic | ✅ |
+| test_ntt_poly_add_wrap | ✅ |
+| test_ntt_poly_add_null | ✅ |
+| test_ntt_poly_sub_basic | ✅ |
+| test_ntt_poly_sub_wrap | ✅ |
+| test_ntt_poly_add_sub_inverse | ✅ |
+| test_ntt_poly_sub_null | ✅ |
+
+*329 / 329 Unity tests PASS*
+
+### Performance
+
+| Function | N | Total | Per call |
+|----------|---|-------|----------|
+| numx_ntt_forward | 10,000 | 18,980 us | 1,898 ns |
+| numx_ntt_inverse | 10,000 | 11,390 us | 1,139 ns |
+| numx_ntt_polymul | 10,000 | 53,180 us | 5,318 ns |
+| numx_ntt_poly_add | 10,000 | 1,210 us | 121 ns |
+| numx_ntt_poly_sub | 10,000 | 1,310 us | 131 ns |
+
+**RESULTS: 29 PASS / 0 FAIL / 29 TOTAL**
+
+---
+
+## Linux x86 - Ubuntu 24.04.4 LTS (WSL2, kernel 6.6.114.1-microsoft-standard-WSL2) / gcc 13.3.0 (-m32, gcc-multilib) / float32
+**Validator:** Amir Ab Khoshk | **Date:** 2026-07-03 | **Commit:** daf5b9c
+
+> Configured with `CMAKE_C_FLAGS=-m32 CMAKE_EXE_LINKER_FLAGS=-m32` against the root
+> CMakeLists.txt, no existing files edited. Confirmed a 32-bit ELF binary via
+> `file build_linux_x86/numx_tests`. Required `gcc-multilib`/`g++-multilib` to be installed
+> in WSL first (installed by the user with sudo, not by this session).
+
+### Test cases
+
+| Test | Result |
+|------|--------|
+| test_ntt_forward_delta | ✅ |
+| test_ntt_forward_zero | ✅ |
+| test_ntt_forward_null | ✅ |
+| test_ntt_inverse_roundtrip_delta | ✅ |
+| test_ntt_inverse_roundtrip_x | ✅ |
+| test_ntt_inverse_roundtrip_x2 | ✅ |
+| test_ntt_inverse_roundtrip_full | ✅ |
+| test_ntt_inverse_null | ✅ |
+| test_ntt_pointwise_mul_identity | ✅ |
+| test_ntt_pointwise_mul_known | ✅ |
+| test_ntt_pointwise_mul_null | ✅ |
+| test_ntt_polymul_delta_identity | ✅ |
+| test_ntt_polymul_x_times_x | ✅ |
+| test_ntt_polymul_wrap_negacyclic | ✅ |
+| test_ntt_polymul_x255_times_x | ✅ |
+| test_ntt_polymul_commutativity | ✅ |
+| test_ntt_polymul_known_linear | ✅ |
+| test_ntt_polymul_random_vs_ref | ✅ |
+| test_ntt_polymul_null | ✅ |
+| test_ntt_reduce_noop_in_range | ✅ |
+| test_ntt_reduce_boundary | ✅ |
+| test_ntt_reduce_null | ✅ |
+| test_ntt_poly_add_basic | ✅ |
+| test_ntt_poly_add_wrap | ✅ |
+| test_ntt_poly_add_null | ✅ |
+| test_ntt_poly_sub_basic | ✅ |
+| test_ntt_poly_sub_wrap | ✅ |
+| test_ntt_poly_add_sub_inverse | ✅ |
+| test_ntt_poly_sub_null | ✅ |
+
+*329 / 329 Unity tests PASS*
+
+### Performance
+
+| Function | N | Total | Per call |
+|----------|---|-------|----------|
+| numx_ntt_forward | 10,000 | 26,250 us | 2,625 ns |
+| numx_ntt_inverse | 10,000 | 18,010 us | 1,801 ns |
+| numx_ntt_polymul | 10,000 | 76,910 us | 7,691 ns |
+| numx_ntt_poly_add | 10,000 | 1,970 us | 197 ns |
+| numx_ntt_poly_sub | 10,000 | 2,010 us | 201 ns |
+
+**RESULTS: 29 PASS / 0 FAIL / 29 TOTAL**
+
+---
+
+## ARM64 - Raspbian GNU/Linux 13 (trixie) / Raspberry Pi 4 Model B / gcc 14.2.0 / float32
+**Validator:** Amir Ab Khoshk | **Date:** 2026-07-03 | **Commit:** daf5b9c
+
+> Validated over SSH (`sellol@raspberrypi.local`), kernel 6.18.33+rpt-rpi-v8 aarch64.
+> Repo was on an older branch, fetched and fast-forwarded to `main` at daf5b9c first.
+> Built from the root CMakeLists.txt, unmodified, Release config.
+
+### Test cases
+
+| Test | Result |
+|------|--------|
+| test_ntt_forward_delta | ✅ |
+| test_ntt_forward_zero | ✅ |
+| test_ntt_forward_null | ✅ |
+| test_ntt_inverse_roundtrip_delta | ✅ |
+| test_ntt_inverse_roundtrip_x | ✅ |
+| test_ntt_inverse_roundtrip_x2 | ✅ |
+| test_ntt_inverse_roundtrip_full | ✅ |
+| test_ntt_inverse_null | ✅ |
+| test_ntt_pointwise_mul_identity | ✅ |
+| test_ntt_pointwise_mul_known | ✅ |
+| test_ntt_pointwise_mul_null | ✅ |
+| test_ntt_polymul_delta_identity | ✅ |
+| test_ntt_polymul_x_times_x | ✅ |
+| test_ntt_polymul_wrap_negacyclic | ✅ |
+| test_ntt_polymul_x255_times_x | ✅ |
+| test_ntt_polymul_commutativity | ✅ |
+| test_ntt_polymul_known_linear | ✅ |
+| test_ntt_polymul_random_vs_ref | ✅ |
+| test_ntt_polymul_null | ✅ |
+| test_ntt_reduce_noop_in_range | ✅ |
+| test_ntt_reduce_boundary | ✅ |
+| test_ntt_reduce_null | ✅ |
+| test_ntt_poly_add_basic | ✅ |
+| test_ntt_poly_add_wrap | ✅ |
+| test_ntt_poly_add_null | ✅ |
+| test_ntt_poly_sub_basic | ✅ |
+| test_ntt_poly_sub_wrap | ✅ |
+| test_ntt_poly_add_sub_inverse | ✅ |
+| test_ntt_poly_sub_null | ✅ |
+
+*329 / 329 Unity tests PASS*
+
+### Performance
+
+| Function | N | Total | Per call |
+|----------|---|-------|----------|
+| numx_ntt_forward | 10,000 | 265,890 us | 26,589 ns |
+| numx_ntt_inverse | 10,000 | 219,660 us | 21,966 ns |
+| numx_ntt_polymul | 10,000 | 813,320 us | 81,332 ns |
+| numx_ntt_poly_add | 10,000 | 24,100 us | 2,410 ns |
+| numx_ntt_poly_sub | 10,000 | 27,370 us | 2,737 ns |
+
+**RESULTS: 29 PASS / 0 FAIL / 29 TOTAL**
+
+---
+
+## ESP32-S3 - ESP-IDF v5.5.2 / Xtensa LX7 / xtensa-esp32s3-elf-gcc 14.2.0 / int16 (q=3329)
+**Validator:** Amir Ab Khoshk | **Date:** 2026-07-03 | **Commit:** daf5b9c
+
+> NTT operates entirely on int16_t (numx_q15_t) with Barrett reduction, no floating-point
+> arithmetic is used.
+>
+> The ESP32 test harness (`tests/esp32_tests/`) has no NTT coverage and wiring it in
+> would require editing 3 existing files (CMakeLists.txt, tests.h, esp32_tests.c), so a
+> new self-contained example project was created instead at `examples/esp32_ntt_test/`
+> (CMakeLists.txt, main/CMakeLists.txt, main/main.c, main/sdkconfig.defaults - all new
+> files, nothing existing modified). It links `src/ntt.c` directly and mirrors the 29
+> test cases in `tests/test_ntt.c`. Built and flashed to a real ESP32-S3 DevKit over
+> USB (COM5) via `idf.py build` / `idf.py -p COM5 flash`, output captured over UART.
+>
+> A stack overflow guard fires a few seconds after the benchmark output finishes
+> printing and reboots the board in a loop; all test and benchmark output is fully
+> captured before that point on every run, so the results below are unaffected. This
+> is a harness artifact (deep stack usage from the many on-stack 256-element
+> `numx_q15_t` buffers across nested calls), not a library bug.
+
+### Test cases
+
+| Test | Result |
+|------|--------|
+| test_ntt_forward_delta | ✅ |
+| test_ntt_forward_zero | ✅ |
+| test_ntt_forward_null | ✅ |
+| test_ntt_inverse_roundtrip_delta | ✅ |
+| test_ntt_inverse_roundtrip_x | ✅ |
+| test_ntt_inverse_roundtrip_x2 | ✅ |
+| test_ntt_inverse_roundtrip_full | ✅ |
+| test_ntt_inverse_null | ✅ |
+| test_ntt_pointwise_mul_identity | ✅ |
+| test_ntt_pointwise_mul_known | ✅ |
+| test_ntt_pointwise_mul_null | ✅ |
+| test_ntt_polymul_delta_identity | ✅ |
+| test_ntt_polymul_x_times_x | ✅ |
+| test_ntt_polymul_wrap_negacyclic | ✅ |
+| test_ntt_polymul_x255_times_x | ✅ |
+| test_ntt_polymul_commutativity | ✅ |
+| test_ntt_polymul_known_linear | ✅ |
+| test_ntt_polymul_random_vs_ref | ✅ |
+| test_ntt_polymul_null | ✅ |
+| test_ntt_reduce_noop_in_range | ✅ |
+| test_ntt_reduce_boundary | ✅ |
+| test_ntt_reduce_null | ✅ |
+| test_ntt_poly_add_basic | ✅ |
+| test_ntt_poly_add_wrap | ✅ |
+| test_ntt_poly_add_null | ✅ |
+| test_ntt_poly_sub_basic | ✅ |
+| test_ntt_poly_sub_wrap | ✅ |
+| test_ntt_poly_add_sub_inverse | ✅ |
+| test_ntt_poly_sub_null | ✅ |
+
+*29 / 29 NTT tests PASS*
+
+### Performance
+
+Note: N=1,000 iterations (not 10,000) to avoid the task watchdog on ESP32-S3.
+`esp_timer_get_time()` returns microseconds; totals are per-call ns times N.
+
+| Function | N | Total | Per call |
+|----------|---|-------|----------|
+| numx_ntt_forward | 1,000 | 767,364 us | 767,364 ns |
+| numx_ntt_inverse | 1,000 | 672,501 us | 672,501 ns |
+| numx_ntt_polymul | 1,000 | 2,444,407 us | 2,444,407 ns |
+| numx_ntt_poly_add | 1,000 | 72,289 us | 72,289 ns |
+| numx_ntt_poly_sub | 1,000 | 78,679 us | 78,679 ns |
+
+**RESULTS: 29 PASS / 0 FAIL / 29 TOTAL**
+
+---
+
+## ARM64 — macOS 26.5.1 / Apple M4 Pro / Apple clang 21.0.0 / float32
+**Validator:** Erfan Jazeb Nikoo | **Date:** 2026-07-03 | **Commit:** c397429
+
+> Built from the root CMakeLists.txt (Release), unmodified. `clock_gettime(CLOCK_MONOTONIC)`
+> timer via `benchmarks/bench_ntt.c`. NTT operates on `numx_q15_t` (int16_t) regardless of
+> `NUMX_USE_DOUBLE`, so the float32/float64 build flag does not affect these results.
+
+### Test cases
+
+| Test | Result |
+|------|--------|
+| test_ntt_forward_delta | ✅ |
+| test_ntt_forward_zero | ✅ |
+| test_ntt_forward_null | ✅ |
+| test_ntt_inverse_roundtrip_delta | ✅ |
+| test_ntt_inverse_roundtrip_x | ✅ |
+| test_ntt_inverse_roundtrip_x2 | ✅ |
+| test_ntt_inverse_roundtrip_full | ✅ |
+| test_ntt_inverse_null | ✅ |
+| test_ntt_pointwise_mul_identity | ✅ |
+| test_ntt_pointwise_mul_known | ✅ |
+| test_ntt_pointwise_mul_null | ✅ |
+| test_ntt_polymul_delta_identity | ✅ |
+| test_ntt_polymul_x_times_x | ✅ |
+| test_ntt_polymul_wrap_negacyclic | ✅ |
+| test_ntt_polymul_x255_times_x | ✅ |
+| test_ntt_polymul_commutativity | ✅ |
+| test_ntt_polymul_known_linear | ✅ |
+| test_ntt_polymul_random_vs_ref | ✅ |
+| test_ntt_polymul_null | ✅ |
+| test_ntt_reduce_noop_in_range | ✅ |
+| test_ntt_reduce_boundary | ✅ |
+| test_ntt_reduce_null | ✅ |
+| test_ntt_poly_add_basic | ✅ |
+| test_ntt_poly_add_wrap | ✅ |
+| test_ntt_poly_add_null | ✅ |
+| test_ntt_poly_sub_basic | ✅ |
+| test_ntt_poly_sub_wrap | ✅ |
+| test_ntt_poly_add_sub_inverse | ✅ |
+| test_ntt_poly_sub_null | ✅ |
+
+*329 / 329 Unity tests PASS*
+
+### Performance
+
+| Function | N | Total | Per call |
+|----------|---|-------|----------|
+| numx_ntt_forward | 10,000 | 11,171 us | 1,117 ns |
+| numx_ntt_inverse | 10,000 | 6,607 us | 660 ns |
+| numx_ntt_polymul | 10,000 | 29,145 us | 2,914 ns |
+| numx_ntt_poly_add | 10,000 | 485 us | 48 ns |
+| numx_ntt_poly_sub | 10,000 | 545 us | 54 ns |
+
+> Fixed a units bug in `benchmarks/bench_ntt.c`'s `bprint()` while running this validation:
+> the "total" column divided by `n` twice, printing per-call-in-µs instead of the true
+> total. Corrected to `total = elapsed_ns / 1000.0` (no `/n`); "per call" was unaffected.
+> Numbers above are from the corrected build.
+
+**RESULTS: 29 PASS / 0 FAIL / 29 TOTAL**


### PR DESCRIPTION
## Summary
- Adds ARM64 (Apple M4 Pro) NTT test + benchmark results (329/329 tests pass) to `validation/results/ntt/ntt.md` and `validation/hardware/mac_mini_m4_pro.md`, run and verified on this machine.
- Merges in the x86-64 / Windows / Linux-x86 / Raspberry Pi 4 / ESP32-S3 NTT results from #45 (Amir Ab Khoshk).
- Fixes a units bug in `benchmarks/bench_ntt.c`: the "total" column divided by `n` twice, printing per-call-in-µs mislabeled as total. Verified before/after on this machine.
- Fixes `README.md`'s benchmark table: NTT rows previously showed unsourced numbers mislabeled "Apple M4 Pro" under the RPi/x86-64/ESP32 columns; replaced with real measured data.
- Fixes `CHANGELOG.md` (NTT test count said 20, actually 29) and `docs/algorithms/ntt.md` (Phase ID `P3.12` → `P3.04`, consistent with the `P3.01`–`P3.03` sequence).
- Adds NTT rows to `validation/hardware/raspberry_pi.md`, a status note to `esp32_devkit_v1.md`, and lists `ntt/` in `validation/README.md`'s directory tree.

## Known remaining gap (tracked separately)
`examples/esp32_ntt_test/`, referenced by the ESP32-S3 results as the harness used to collect them, isn't present on any branch of Amir's fork — asking him to push it in a follow-up so the ESP32 numbers are reproducible.

## Test plan
- [x] `cmake -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build --parallel` — clean build
- [x] `./build/numx_tests` — 329/329 PASS
- [x] `./build/numx_bench` — NTT totals sane after the `bench_ntt.c` fix