### PR TITLE
release: v1.0.0 -- first stable release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) — versioning:
 
 ---
 
-## [0.2.0] — 2026-07-03
+## [1.0.0] — 2026-07-03
+
+First stable release. Completes the full 4-phase plan (foundation, signal
+processing, unicorn algorithms, hardening) with the addition of the NTT
+(post-quantum) module. 14 modules, 329 tests, validated across 10
+platform/toolchain combinations.
 
 ### Added
 
@@ -113,5 +118,5 @@ Initial public release.
 
 ---
 
-[0.2.0]: https://github.com/NIKX-Tech/numx/releases/tag/v0.2.0
+[1.0.0]: https://github.com/NIKX-Tech/numx/releases/tag/v1.0.0
 [0.1.0]: https://github.com/NIKX-Tech/numx/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ All results are device-run, per-formula values with measured error margins — n
 include(FetchContent)
 FetchContent_Declare(numx
   GIT_REPOSITORY https://github.com/NIKX-Tech/numx.git
-  GIT_TAG        v0.2.0
+  GIT_TAG        v1.0.0
 )
 FetchContent_MakeAvailable(numx)
 target_link_libraries(my_target PRIVATE numx::numx)

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -3,7 +3,7 @@
 
 cmake_minimum_required: "3.16"
 
-version: "0.2.0"
+version: "1.0.0"
 description: >
   Scientific-grade numerical computing for ESP32 (and all embedded targets).
   Pure C99, zero dynamic allocation, zero external dependencies. Provides

--- a/include/numx/numx_types.h
+++ b/include/numx/numx_types.h
@@ -62,8 +62,8 @@ typedef numx_real_t (*numx_func1d_t)(numx_real_t x);
 #define NUMX_PI 3.14159265358979323846f
 #endif
 
-#define NUMX_VERSION_MAJOR 0
-#define NUMX_VERSION_MINOR 2
+#define NUMX_VERSION_MAJOR 1
+#define NUMX_VERSION_MINOR 0
 #define NUMX_VERSION_PATCH 0
 
 #endif /* NUMX_TYPES_H */

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "numx",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "Scientific-grade numerical computing for embedded systems. Zero dependencies, zero dynamic allocation, pure C99. Linear algebra, signal processing, FFT, ODE solvers, automatic differentiation, compressed sensing, post-quantum NTT (CRYSTALS-Kyber/Dilithium), and more.",
   "keywords": [
     "numerical", "math", "linear-algebra", "signal-processing", "fft",

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=numx
-version=0.2.0
+version=1.0.0
 author=NIKX Technologies B.V.
 maintainer=NIKX Technologies B.V. <hi@nikx.one>
 sentence=Scientific-grade numerical computing for ESP32 and Arduino-compatible boards.


### PR DESCRIPTION
## Summary
Retags what was briefly released as v0.2.0 into v1.0.0, matching this project's own documented plan.

CONTEXT.md (single source of truth for project planning) marks NTT's completion as the intended v1.0.0 milestone: it closes the full 4-phase plan (foundation, signal processing, unicorn algorithms, hardening), with a "Roadmap Beyond v1.0.0" section describing what comes next (a full Kyber/Dilithium PQC library, RISC-V hardware validation, an academic paper, a Kalman filter module). This got missed when v0.2.0 was tagged off a stale note in the old pre-NTT CHANGELOG instead.

**Already done, outside this PR:**
- Deleted the v0.2.0 GitHub release and git tag (published under 2 days, nothing external depended on it, nothing had been publicly announced yet)

**This PR:**
- Version bumped to 1.0.0 across all four anchors (`numx_types.h`, `library.properties`, `library.json`, `idf_component.yml`)
- README's `FetchContent` `GIT_TAG` updated to `v1.0.0`
- CHANGELOG's `[0.2.0]` section renamed to `[1.0.0]`, with a short note on what the milestone completes

## Test plan
- [x] Clean build, 329/329 tests pass
- [x] `examples/06_ntt.c` runs and produces correct output

## After merge
Will tag `v1.0.0` and create the GitHub Release, then update the website (currently mid-flight on the same v0.2.0 -> v1.0.0 correction).