### PR TITLE
docs(ntt): make the constant-time caveat prominent, not buried

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,11 @@ Every function is reentrant, allocation-free, and returns a typed status code. T
 | [**autodiff**](docs/algorithms/autodiff.md) | forward-mode (dual numbers), reverse-mode (static tape) | ✅ complete |
 | [**compressed_sensing**](docs/algorithms/compressed_sensing.md) | OMP, ISTA | ✅ complete |
 | [**sketch**](docs/algorithms/sketch.md) | randomized SVD (Halko-Martinsson-Tropp) | ✅ complete |
-| [**ntt**](docs/algorithms/ntt.md) | Number Theoretic Transform (Kyber/Dilithium params) | ✅ complete |
+| [**ntt**](docs/algorithms/ntt.md) | Number Theoretic Transform (Kyber/Dilithium params) | ✅ complete ⚠️ |
+
+> ⚠️ `ntt` is not fully constant-time — see the warning at the top of
+> [`docs/algorithms/ntt.md`](docs/algorithms/ntt.md) before using it for secret key
+> material.
 
 ---
 

--- a/docs/algorithms/ntt.md
+++ b/docs/algorithms/ntt.md
@@ -4,6 +4,16 @@
 
 ---
 
+> ⚠️ **Not fully constant-time. Do not use for production handling of secret key
+> material without independent review.** The transform stages (butterfly network,
+> table lookups) are data-independent, but the Barrett-reduction canonicalization
+> step uses a conditional branch that is not guaranteed constant-time on
+> branch-predicting CPUs. See [Barrett reduction](#barrett-reduction) below for the
+> full explanation. This is a numerical implementation of the NTT, not an audited
+> cryptographic primitive.
+
+---
+
 ## What it solves
 
 Multiplies polynomials in the ring Z_3329[x]/(x^256 + 1) in O(n log n) time using


### PR DESCRIPTION
Direct response to feedback on r/cryptography: `docs/algorithms/ntt.md` and README.md now flag the constant-time caveat at the top, not buried mid-page.