### PR TITLE
docs: add a direct note on AI-assisted development

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,6 +96,20 @@ Before opening a PR:
 
 ---
 
+## On AI-assisted development
+
+numx is built with Claude Code as a tool, used under direction and reviewed at every
+step, not run unsupervised. Concretely: implementation scaffolding, multi-platform
+validation runs, sanitizer testing, and documentation are commonly done with AI
+assistance. Architecture decisions (zero allocation, no external dependencies, module
+boundaries), the underlying math, and validation methodology are human-directed, and
+every change is reviewed before it ships, including catching AI's own mistakes along
+the way. If you're evaluating this project and that changes your assessment of it,
+that's a reasonable reaction to have, this note exists so you don't have to go dig for
+the answer.
+
+The prompt pattern below is the actual template used when adding a new module.
+
 ## Prompt pattern for Claude Code
 
 When implementing a new algorithm, use this exact prompt:

--- a/README.md
+++ b/README.md
@@ -175,7 +175,8 @@ Per-call averages measured on physical hardware. Full tables: [`validation/resul
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the rules, templates, and the exact
-prompt pattern to use with Claude Code when adding a new algorithm. See
+prompt pattern to use with Claude Code when adding a new algorithm, including a
+direct note on how AI assistance is and isn't used in this project. See
 [CONTRIBUTORS.md](CONTRIBUTORS.md) for the people who have contributed to numx.
 
 ---


### PR DESCRIPTION
Prompted by a question on r/embedded. States plainly what CONTRIBUTING.md's Claude Code prompt-pattern section only implied: AI tooling is used, under direction and review, for implementation scaffolding, validation, sanitizer testing, and docs. Architecture, math, and validation methodology are human-directed. Linked from README.md.