### PR TITLE
security(ntt): make Barrett reduction branchless, closing the constant-time gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) — versioning:
   ARM64/Apple M4 Pro (float32 and float64, ASan/UBSan clean); full platform sweep
   pending.
 
+### Security
+- `ntt`: rewrote `priv_barrett`'s canonicalization step (`src/ntt.c`) to be
+  branchless, resolving the module's one known constant-time gap flagged in
+  `docs/algorithms/ntt.md`. The previous version's `if (r < 0) ... if (r >= q) ...`
+  used data-dependent branches; the new version uses only unsigned arithmetic and
+  a well-defined C99 boolean comparison. Fix contributed by u/robchroma
+  (r/C_Programming); exhaustively verified against `a % q` for all 22,164,483
+  valid inputs before adoption. No known data-dependent branches remain in the
+  transform.
+
 ---
 
 ## [1.0.0] — 2026-07-03

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,6 +9,7 @@ of the project.
 | [Amir Ab Khoshk](https://github.com/abkhoshk) | Hardware validation lead. Ran the full test and benchmark suite across Linux x86/x86-64, Windows x86/x64, Raspberry Pi 4, and ESP32-S3, producing the platform validation results under `validation/`. |
 | [Sepand Haghighi](https://github.com/sepandhaghighi) | Early collaborator on the project's original 2021 prototype, reviewing and merging the first integration module (`src/integral/`), later kept as historical reference under `archive/legacy_integral/` and used as the algorithmic basis for Phase 1's `numx_integrate_trap` and `numx_integrate_simpson`. |
 | [Erfan Esmaeili, PhD](https://github.com/erfanili) | Contributed the Cholesky decomposition implementation (`numx_cholesky_decompose`) in the `linalg` module, including its unit test suite. |
+| u/robchroma (r/C_Programming) | Identified that the NTT module's Barrett-reduction canonicalization could be made branchless without relying on implementation-defined behavior, and contributed the fix used in `priv_barrett` (`src/ntt.c`), resolving the module's one known constant-time gap. |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -49,11 +49,12 @@ Every function is reentrant, allocation-free, and returns a typed status code. T
 | [**autodiff**](docs/algorithms/autodiff.md) | forward-mode (dual numbers), reverse-mode (static tape) | ✅ complete |
 | [**compressed_sensing**](docs/algorithms/compressed_sensing.md) | OMP, ISTA | ✅ complete |
 | [**sketch**](docs/algorithms/sketch.md) | randomized SVD (Halko-Martinsson-Tropp) | ✅ complete |
-| [**ntt**](docs/algorithms/ntt.md) | Number Theoretic Transform (Kyber/Dilithium params) | ✅ complete ⚠️ |
+| [**ntt**](docs/algorithms/ntt.md) | Number Theoretic Transform (Kyber/Dilithium params) | ✅ complete |
 
-> ⚠️ `ntt` is not fully constant-time — see the warning at the top of
-> [`docs/algorithms/ntt.md`](docs/algorithms/ntt.md) before using it for secret key
-> material.
+> No known data-dependent branches remain in `ntt` as of 2026-07-10 (see
+> [`docs/algorithms/ntt.md`](docs/algorithms/ntt.md#barrett-reduction)), but it is
+> not a formally audited cryptographic primitive, get independent review before
+> production use with real secret key material.
 
 ---
 

--- a/docs/algorithms/ntt.md
+++ b/docs/algorithms/ntt.md
@@ -4,13 +4,16 @@
 
 ---
 
-> ⚠️ **Not fully constant-time. Do not use for production handling of secret key
-> material without independent review.** The transform stages (butterfly network,
-> table lookups) are data-independent, but the Barrett-reduction canonicalization
-> step uses a conditional branch that is not guaranteed constant-time on
-> branch-predicting CPUs. See [Barrett reduction](#barrett-reduction) below for the
-> full explanation. This is a numerical implementation of the NTT, not an audited
-> cryptographic primitive.
+> ℹ️ **Constant-time status (updated 2026-07-10):** no data-dependent branches are
+> known in this implementation. The transform stages (butterfly network, table
+> lookups) were always data-independent; the Barrett-reduction canonicalization
+> step (previously the one known exception) was rewritten to a branchless form
+> using only unsigned arithmetic and exhaustively verified correct against
+> `a % q` for all 22,164,483 valid inputs. See
+> [Barrett reduction](#barrett-reduction) below for detail. This is still a
+> numerical implementation of the NTT, not a formally audited cryptographic
+> primitive, independent review is recommended before production use with real
+> secret key material.
 
 ---
 
@@ -123,21 +126,28 @@ $$(a_0 + a_1 x)(b_0 + b_1 x) \bmod (x^2 - c_i) = (a_0 b_0 + c_i a_1 b_1) + (a_0 
 All modular multiplications use Barrett reduction to avoid the hardware division
 instruction, which is slow or absent on embedded processors:
 
-$$\text{barrett}(a) = a - \left\lfloor \frac{a \cdot v}{2^{26}} \right\rfloor \cdot q, \qquad v = \left\lceil \frac{2^{26}}{3329} \right\rceil = 20159$$
+$$\text{barrett}(a) = a - \left\lfloor \frac{(a \ggg 10) \cdot v}{2^{15}} \right\rfloor \cdot q, \qquad v = 10079$$
 
-For inputs in $[0,\, 2q^2] \approx [0,\, 22\text{M}]$, a single conditional subtract
-brings the result into $[0, q-1]$. The 32-bit intermediate product fits in a 64-bit
-integer (available as `uint64_t` in C99).
+For inputs in $[0,\, 2q^2] \approx [0,\, 22\text{M}]$, this always lands within
+$[0, 2q)$, so a single branchless canonicalization step brings the result into
+$[0, q-1]$:
 
-> **Side-channel note:** the canonicalization step (`if (r < 0) r += q; if (r >= q)
-> r -= q;` in `priv_barrett`) uses data-dependent conditional branches. On CPUs with
-> branch prediction (most x86-64 and ARM Cortex-A cores), this is not guaranteed to
-> execute in constant time, unlike the branchless technique used in the reference
-> CRYSTALS-Kyber implementation (`a -= q; a += (a >> 15) & q;`). Every other stage of
-> the transform (butterfly network, twiddle-table lookups) has fixed, data-independent
-> control flow. This distinction only matters if you are handling secret polynomial
-> coefficients (e.g. a private key) and need timing-attack resistance — for general
-> numerical use the results are identical either way.
+```c
+uint16_t r = (uint16_t)(a - t * q);
+uint16_t b = (uint16_t)((1 << 15) - (r >= q));
+r = (uint16_t)(r - (q & b));
+```
+
+`b` is `0x7FFF` when `r >= q` and `0x8000` otherwise; ANDing with `q` (which has no
+bit set at position 15) selects `q` or `0` without a branch. This uses only unsigned
+arithmetic and a boolean comparison (`r >= q` evaluates to exactly 0 or 1, well-defined
+in C99), unlike the reference CRYSTALS-Kyber technique (`a -= q; a += (a >> 15) & q;`),
+which relies on arithmetic right-shift of a negative signed int, implementation-defined
+behavior. Combined with the transform stages (butterfly network, twiddle-table lookups),
+which have always had fixed, data-independent control flow, this implementation has no
+known data-dependent branches. Contributed by u/robchroma (r/C_Programming, 2026-07-10)
+and exhaustively verified against `a % q` for all 22,164,483 valid inputs before
+adoption.
 
 ---
 

--- a/src/ntt.c
+++ b/src/ntt.c
@@ -19,11 +19,12 @@
 
 /* ── Domain constants ──────────────────────────────────────────────── */
 
-#define NTT_Q       3329
-#define NTT_N       256
-#define NTT_N_INV   3303   /* 128^{-1} mod 3329 */
-#define NTT_BVAL    20159  /* ceil(2^26 / 3329) for Barrett reduction  */
-#define NTT_BSHIFT  26
+#define NTT_Q          3329
+#define NTT_N          256
+#define NTT_N_INV      3303   /* 128^{-1} mod 3329 */
+#define NTT_BVAL       10079  /* Barrett multiplier, branchless reduction below */
+#define NTT_BPRESHIFT  10
+#define NTT_BSHIFT     15
 
 /* ── Precomputed twiddle tables ────────────────────────────────────── */
 
@@ -91,22 +92,23 @@ static const int16_t priv_basemul[128] = {
 
 /*
  * Barrett reduction mod 3329 for inputs in [0, 2*q^2].
- * v = ceil(2^26/3329) = 20159.
  *
- * Note: the canonicalization branches below are data-dependent and not
- * guaranteed constant-time on branch-predicting CPUs. See "Side-channel
- * note" in docs/algorithms/ntt.md if you need timing-attack resistance
- * for secret-dependent inputs.
+ * Branchless canonicalization: uses only unsigned arithmetic and a boolean
+ * comparison (well-defined in C99), not the reference Kyber technique's
+ * `a += (a >> 15) & q`, which relies on arithmetic right-shift of a negative
+ * signed int, implementation-defined behavior. Exhaustively verified correct
+ * against a % q for all 22,164,483 inputs in [0, 2*q^2] before adoption.
+ * Contributed by u/robchroma (r/C_Programming), 2026-07-10.
  */
 static int16_t priv_barrett(int32_t a)
 {
-    int32_t t;
-    int16_t r;
-    t = (int32_t)(((uint64_t)(uint32_t)a * 20159u) >> 26u);
-    r = (int16_t)(a - t * 3329);
-    if (r < 0)     r = (int16_t)(r + 3329);
-    if (r >= 3329) r = (int16_t)(r - 3329);
-    return r;
+    int32_t  t;
+    uint16_t r, b;
+    t = (int32_t)(((a >> NTT_BPRESHIFT) * NTT_BVAL) >> NTT_BSHIFT);
+    r = (uint16_t)(a - t * NTT_Q);
+    b = (uint16_t)((1 << 15) - (r >= NTT_Q));
+    r = (uint16_t)(r - (NTT_Q & b));
+    return (int16_t)r;
 }
 
 /* Single field multiplication reduced to [0, q-1]. */


### PR DESCRIPTION
## Summary
Direct response to feedback on r/C_Programming (Bman1296, robchroma, AttractiveDaddy) on the constant-time caveat documented in `docs/algorithms/ntt.md`. u/robchroma proposed a branchless canonicalization for `priv_barrett` that avoids the implementation-defined-behavior problem with the reference Kyber technique.

## Verification
- Exhaustively checked against `a % q` for all 22,164,483 valid inputs in `[0, 2*q^2]`, zero mismatches (not spot-checked)
- Full test suite: 335/335 passing
- AddressSanitizer + UndefinedBehaviorSanitizer: clean
- `-std=c99 -pedantic-errors -Wall -Wextra -Werror` on both gcc and clang: zero warnings

## Docs
Updates the constant-time warning in `docs/algorithms/ntt.md` and `README.md` to reflect the fix, while keeping the honest caveat that this isn't a formally audited cryptographic primitive. Credits robchroma in `CONTRIBUTORS.md`, adds a `### Security` entry to `CHANGELOG.md`.

## Not done here (separate, larger decision)
This closes the specific constant-time gap that was documented and publicly flagged. It does not constitute a security audit of the NTT module as a whole.