### PR TITLE
Complete multi-platform validation for numx_cholesky_decompose

### DIFF
--- a/examples/esp32_cholesky_test/CMakeLists.txt
+++ b/examples/esp32_cholesky_test/CMakeLists.txt
@@ -1,0 +1,3 @@
+cmake_minimum_required(VERSION 3.16)
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(esp32_cholesky_test)

--- a/examples/esp32_cholesky_test/main/CMakeLists.txt
+++ b/examples/esp32_cholesky_test/main/CMakeLists.txt
@@ -1,0 +1,8 @@
+idf_component_register(
+    SRCS
+        "main.c"
+        "../../../src/linalg.c"
+    INCLUDE_DIRS "../../../include"
+    PRIV_REQUIRES esp_timer
+)
+target_compile_options(${COMPONENT_LIB} PRIVATE -O2 -std=c99 -Wno-unused-parameter)

--- a/examples/esp32_cholesky_test/main/main.c
+++ b/examples/esp32_cholesky_test/main/main.c
@@ -1,0 +1,164 @@
+/**
+ * @file main.c
+ * @brief Self-contained ESP32-S3 test/bench harness for numx's
+ * numx_cholesky_decompose.
+ *
+ * Mirrors the 6 test cases in tests/test_linalg.c without depending on
+ * Unity, so this project links src/linalg.c directly and needs nothing
+ * beyond the ESP-IDF freertos/esp_timer components. Results and benchmark
+ * numbers are printed over UART.
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include "esp_timer.h"
+#include "numx/linalg.h"
+
+static int g_pass = 0;
+static int g_fail = 0;
+
+#define CHK(cond, label) do { \
+    if (cond) { g_pass++; } \
+    else { g_fail++; printf("  FAIL: %s\n", (label)); } \
+} while (0)
+
+#define CHK_STATUS(exp, got, label) CHK((exp) == (got), label)
+
+static int approx(numx_real_t a, numx_real_t b, numx_real_t tol)
+{
+    numx_real_t d = a - b;
+    if (d < 0)
+        d = -d;
+    return d <= tol;
+}
+
+#define TOL ((numx_real_t)1e-3)
+
+/* L1 */
+static void test_cholesky_decompose_3x3_success(void)
+{
+    numx_size_t n = 3;
+    const numx_real_t A[9] = {
+         4.0f,  12.0f, -16.0f,
+        12.0f,  37.0f, -43.0f,
+       -16.0f, -43.0f,  98.0f
+    };
+    numx_real_t L[9];
+
+    CHK_STATUS(NUMX_OK, numx_cholesky_decompose(A, n, L), "3x3_success status");
+
+    CHK(approx(L[0*3 + 0],  2.0f, TOL), "3x3_success L00");
+    CHK(approx(L[0*3 + 1],  0.0f, TOL), "3x3_success L01");
+    CHK(approx(L[0*3 + 2],  0.0f, TOL), "3x3_success L02");
+
+    CHK(approx(L[1*3 + 0],  6.0f, TOL), "3x3_success L10");
+    CHK(approx(L[1*3 + 1],  1.0f, TOL), "3x3_success L11");
+    CHK(approx(L[1*3 + 2],  0.0f, TOL), "3x3_success L12");
+
+    CHK(approx(L[2*3 + 0], -8.0f, TOL), "3x3_success L20");
+    CHK(approx(L[2*3 + 1],  5.0f, TOL), "3x3_success L21");
+    CHK(approx(L[2*3 + 2],  3.0f, TOL), "3x3_success L22");
+}
+
+/* L2 */
+static void test_cholesky_decompose_residual_reconstruction(void)
+{
+    numx_size_t n = 3;
+    const numx_real_t A[9] = {
+         4.0f,  12.0f, -16.0f,
+        12.0f,  37.0f, -43.0f,
+       -16.0f, -43.0f,  98.0f
+    };
+    numx_real_t L[9], LT[9], LLT[9];
+    numx_size_t i;
+
+    numx_cholesky_decompose(A, n, L);
+    numx_mat_transpose(L, n, n, LT);
+    numx_mat_mul(L, n, n, LT, n, n, LLT);
+
+    for (i = 0; i < n * n; i++)
+        CHK(approx(A[i], LLT[i], TOL), "residual_reconstruction LLT != A");
+}
+
+/* L3 */
+static void test_cholesky_decompose_non_spd_fail(void)
+{
+    numx_size_t n = 3;
+    const numx_real_t A[9] = {
+        0.0f, 1.0f, 2.0f,
+        1.0f, 5.0f, 6.0f,
+        2.0f, 6.0f, 9.0f
+    };
+    numx_real_t L[9];
+
+    CHK_STATUS(NUMX_ERR_SINGULAR, numx_cholesky_decompose(A, n, L), "non_spd_fail");
+}
+
+/* L4 */
+static void test_cholesky_decompose_null_A(void)
+{
+    numx_real_t L[4];
+    CHK_STATUS(NUMX_ERR_NULL_PTR, numx_cholesky_decompose(NULL, 2, L), "null_A");
+}
+
+static void test_cholesky_decompose_null_L(void)
+{
+    numx_real_t A[4] = {4.0f, 0.0f, 0.0f, 4.0f};
+    CHK_STATUS(NUMX_ERR_NULL_PTR, numx_cholesky_decompose(A, 2, NULL), "null_L");
+}
+
+static void test_cholesky_decompose_invalid_dim(void)
+{
+    numx_real_t L[4];
+    numx_real_t A[4] = {4.0f, 0.0f, 0.0f, 4.0f};
+    CHK_STATUS(NUMX_ERR_INVALID_ARG, numx_cholesky_decompose(A, 0, L), "invalid_dim");
+}
+
+static void run_all_tests(void)
+{
+    test_cholesky_decompose_3x3_success();
+    test_cholesky_decompose_residual_reconstruction();
+    test_cholesky_decompose_non_spd_fail();
+    test_cholesky_decompose_null_A();
+    test_cholesky_decompose_null_L();
+    test_cholesky_decompose_invalid_dim();
+}
+
+/* ── Benchmark ─────────────────────────────────────────────────────── */
+
+#define BENCH_N 100000
+
+static void run_benchmarks(void)
+{
+    numx_size_t n = 3;
+    const numx_real_t A[9] = {
+         4.0f,  12.0f, -16.0f,
+        12.0f,  37.0f, -43.0f,
+       -16.0f, -43.0f,  98.0f
+    };
+    numx_real_t L[9];
+    int i;
+    int64_t t0, t1, us, ns_per_call;
+
+    printf("\n| %-24s | N      | Total          | Per call   |\n", "Function");
+    printf("|--------------------------|--------|----------------|------------|\n");
+
+    t0 = esp_timer_get_time();
+    for (i = 0; i < BENCH_N; i++)
+        numx_cholesky_decompose(A, n, L);
+    t1 = esp_timer_get_time();
+    us = t1 - t0;
+    ns_per_call = (us * 1000LL) / BENCH_N;
+    printf("| %-24s | %6d | %10lld us | %10lld ns |\n",
+           "cholesky_decompose 3x3", BENCH_N, (long long)us, (long long)ns_per_call);
+}
+
+void app_main(void)
+{
+    printf("=== numx cholesky_decompose self-contained test/bench harness (ESP32-S3) ===\n");
+    run_all_tests();
+    printf("\nRESULTS: %d PASS / %d FAIL / %d TOTAL\n", g_pass, g_fail, g_pass + g_fail);
+
+    run_benchmarks();
+    printf("\n=== done ===\n");
+}

--- a/examples/esp32_cholesky_test/main/sdkconfig.defaults
+++ b/examples/esp32_cholesky_test/main/sdkconfig.defaults
@@ -1,0 +1,5 @@
+# Self-contained cholesky_decompose test/bench harness for ESP32-S3.
+CONFIG_ESP_MAIN_TASK_STACK_SIZE=8192
+
+# UART console at a common baud rate for capturing test/bench output.
+CONFIG_ESP_CONSOLE_UART_BAUDRATE=115200

--- a/validation/prompts/cholesky_rpi_esp32_validation_prompt.md
+++ b/validation/prompts/cholesky_rpi_esp32_validation_prompt.md
@@ -1,0 +1,122 @@
+# Validation prompt: numx_cholesky_decompose on Raspberry Pi 4 and ESP32-S3
+
+> **Status: complete ✅ (2026-07-12).** Both platforms below have been validated — see
+> the "ARMv7 (armhf)" and "ESP32-S3" sections in
+> [`validation/results/linalg/cholesky_decompose.md`](../results/linalg/cholesky_decompose.md).
+> Notably, the Pi turned out to be running a 32-bit armhf userland on a 64-bit kernel
+> (not aarch64 as originally assumed — see that section's notes), and the ESP32-S3 run
+> needed a new self-contained example at `examples/esp32_cholesky_test/` (same pattern
+> as `examples/esp32_ntt_test/`) since the on-device harness has no cholesky coverage.
+> This file is kept as a record of the workflow used; the instructions below still
+> apply if this ever needs to be re-run (e.g. after a future implementation change).
+
+Self-contained instructions for finishing the multi-platform validation sweep for
+`numx_cholesky_decompose` (merged in [#51](https://github.com/NIKX-Tech/numx/pull/51),
+contributed by Erfan Esmaeili). Windows x86/x64 and Linux x86/x86-64 (WSL2) are already
+done — see [`validation/results/linalg/cholesky_decompose.md`](../results/linalg/cholesky_decompose.md).
+This mirrors the workflow used for the NTT module's hardware validation (commits
+`068b332`, `1a50e3c`, see [`validation/results/ntt/ntt.md`](../results/ntt/ntt.md) for
+the reference output format).
+
+Give this file to whoever has physical access to the two boards (or their SSH/serial
+sessions) — Claude Code or a human — as the task prompt.
+
+## What "done" looks like
+
+Two new sections appended to `validation/results/linalg/cholesky_decompose.md`, one per
+platform, in the same format as the existing ARM64/Windows/Linux sections in that file:
+header line (`## <arch> — <OS/board> / <compiler> / <precision>`), a validator/date/commit
+line, a short prose note on how the build was done, a **Test cases** table, a **Performance**
+table, and a `**RESULTS: N PASS / 0 FAIL / N TOTAL**` line. Do not edit or reformat the
+existing sections — only append.
+
+Also update the `## Remaining validation` section at the bottom of that file once both
+platforms are done (remove the pending note, or delete the section entirely if nothing
+is left).
+
+---
+
+## Part 1 — Raspberry Pi 4 (aarch64 / gcc)
+
+Reference hardware profile: [`validation/hardware/raspberry_pi.md`](../hardware/raspberry_pi.md)
+(Raspbian GNU/Linux 13, gcc 14.2.0, Cortex-A72, float32 by default).
+
+1. SSH into the Pi. Fetch and check out the latest commit on `main` (or whichever branch
+   has the Cholesky work — confirm with `git log --oneline -1 -- src/linalg.c` that
+   `numx_cholesky_decompose` is present before proceeding).
+2. Build unmodified, Release config, from the root `CMakeLists.txt` — do not edit any
+   existing CMake files:
+   ```
+   cmake -S . -B build_rpi -DCMAKE_BUILD_TYPE=Release
+   cmake --build build_rpi -j4 --target numx_tests numx_val_runner
+   ```
+3. Run `./build_rpi/numx_tests`, confirm 0 failures, and pull out the six
+   `test_cholesky_decompose_*` lines (`3x3_success`, `residual_reconstruction`,
+   `non_spd_fail`, `null_A`, `null_L`, `invalid_dim`) plus the final `N Tests 0
+   Failures 0 Ignored` summary line.
+4. Run `./build_rpi/numx_val_runner`, grab the `numx_cholesky_decompose` block (six
+   `L[i][j]` checks against the textbook 3×3 SPD matrix, plus the `BENCH cholesky_decompose
+   3×3` timing line — this is where the Performance table numbers come from). Confirm no
+   `FAIL` lines in that block.
+5. If float64 validation is also wanted on this platform (optional — the existing sweep
+   only ran RPi at float32, matching its hardware profile default), repeat step 2 with
+   `-DCMAKE_C_FLAGS="-DNUMX_USE_DOUBLE -DUNITY_INCLUDE_DOUBLE"` into a separate build
+   directory (e.g. `build_rpi_f64`), and repeat steps 3–4.
+6. Write the results into `validation/results/linalg/cholesky_decompose.md`, matching the
+   existing table format (see the ARM64/Windows/Linux sections already in that file as the
+   template). Include validator name, date, and short commit hash. Note the compiler
+   version (`gcc --version`) and kernel (`uname -r`) in the header, same style as the
+   RPi section in `validation/results/ntt/ntt.md`.
+
+## Part 2 — ESP32-S3 (Xtensa LX7 / ESP-IDF)
+
+Reference hardware profile: [`validation/hardware/esp32_devkit_v1.md`](../hardware/esp32_devkit_v1.md).
+
+The existing on-device test harness (`tests/esp32_tests/`) does **not** cover
+`numx_cholesky_decompose` — same gap the NTT module had. Do not wire it into that harness
+(it would require editing `CMakeLists.txt`, `tests.h`, and `esp32_tests.c`). Instead,
+follow the pattern already established at `examples/esp32_ntt_test/` and create a new,
+self-contained example project at `examples/esp32_cholesky_test/`:
+
+```
+examples/esp32_cholesky_test/
+├── CMakeLists.txt              ← top-level ESP-IDF project file (copy+adapt from esp32_ntt_test)
+├── main/
+│   ├── CMakeLists.txt          ← component registration, links src/linalg.c directly
+│   ├── main.c                  ← test + bench entry point (app_main)
+│   └── sdkconfig.defaults
+```
+
+1. `main.c` should mirror the 6 Unity cases in `tests/test_linalg.c`
+   (`test_cholesky_decompose_3x3_success`, `_residual_reconstruction`, `_non_spd_fail`,
+   `_null_A`, `_null_L`, `_invalid_dim`) as plain `printf`-based checks (no Unity
+   dependency needed, same approach as `examples/esp32_ntt_test/main/main.c`), plus a
+   timing loop around `numx_cholesky_decompose` using `esp_timer_get_time()`.
+2. Cap benchmark iterations well below what the NTT example used (that one had to drop
+   from N=10,000 to N=1,000 to dodge the task watchdog) — start at N=1,000 for the 3×3
+   case and reduce further if the watchdog fires. Cholesky is O(n³) but n=3 here, so a
+   few thousand iterations should be safe; adjust based on actual runtime.
+3. Build and flash over USB:
+   ```
+   idf.py build
+   idf.py -p <COM_PORT> flash monitor
+   ```
+   Capture the full UART output (test PASS/FAIL lines + bench total/per-call numbers)
+   before any watchdog reset. If a stack-overflow guard fires after output completes
+   (as it did for the NTT run — a harness artifact from deep on-stack buffer usage, not
+   a library bug), that's fine as long as all test/bench output printed first.
+4. Write the results into `validation/results/linalg/cholesky_decompose.md`, same table
+   format as the other sections. Note ESP-IDF version, Xtensa toolchain version, and
+   whether float32 or int-only arithmetic was used (Cholesky is float, unlike NTT's
+   int16 Barrett-reduction path — so `NUMX_USE_DOUBLE` is N/A here unless you also want
+   an ESP32 float64 run, which is unusual for this MCU and can be skipped).
+
+## Notes carried over from the NTT precedent
+
+- Do not edit any existing files outside of what's explicitly required (new CMake/example
+  files are fine; do not touch `tests/esp32_tests/*` or the root `CMakeLists.txt`).
+- If the repo checkout on either board is stale, fetch/fast-forward to the commit that has
+  `numx_cholesky_decompose` before validating, and note the actual commit hash used in the
+  result file header (not the one in this prompt).
+- Record precision as it actually ran (float32/float64), not assumed from the hardware
+  profile default.

--- a/validation/results/linalg/cholesky_decompose.md
+++ b/validation/results/linalg/cholesky_decompose.md
@@ -10,9 +10,9 @@ Covers: `numx_cholesky_decompose`
 > Implementation contributed by Erfan Esmaeili ([#51](https://github.com/NIKX-Tech/numx/pull/51)).
 > Verified with AddressSanitizer and UndefinedBehaviorSanitizer (335/335 tests, zero
 > issues) and compiled clean under `-std=c99 -pedantic-errors -Wall -Wextra -Werror`
-> in both float32 and float64. Only one platform validated so far; full multi-platform
-> sweep (Windows, Raspberry Pi, ESP32-S3) to follow, matching every other function in
-> this table.
+> in both float32 and float64. The sections below complete the full multi-platform
+> sweep: Windows x86/x64, Linux x86 (32-bit)/x86-64 (WSL2), Raspberry Pi 4 (armhf),
+> and ESP32-S3 (Xtensa LX7).
 
 ### Test cases
 
@@ -39,8 +39,257 @@ Covers: `numx_cholesky_decompose`
 
 ---
 
-## Remaining validation
+## Windows x86 - Windows 11 / MSVC 19.51.36248.0 (VS 2026 Build Tools) / float32
+**Validator:** Amir Ab Khoshk | **Date:** 2026-07-12 | **Commit:** 4dc881f
 
-Not yet run: Windows x64 (MSVC), Raspberry Pi 4 (aarch64/gcc), ESP32-S3 (Xtensa/ESP-IDF),
-Linux x86-64. Needed before this function carries the same validation weight as the
-rest of `linalg`.
+> Built with the Win32 CMake generator platform (`cmake -S . -B build_x86 -A Win32`),
+> producing a 32-bit Intel i386 binary, confirmed via `file build_x86/Release/numx_tests.exe`.
+> Uses `numx_real_t = float` (no `NUMX_USE_DOUBLE`). No existing CMake files edited.
+
+### Test cases
+
+| Test | Result |
+|------|--------|
+| test_cholesky_decompose_3x3_success | ✅ |
+| test_cholesky_decompose_residual_reconstruction | ✅ |
+| test_cholesky_decompose_non_spd_fail | ✅ |
+| test_cholesky_decompose_null_A | ✅ |
+| test_cholesky_decompose_null_L | ✅ |
+| test_cholesky_decompose_invalid_dim | ✅ |
+
+*337 / 337 Unity tests PASS*
+
+### Validation-runner checks
+
+| Function | Input / scenario | Expected | Computed | Error | Pass |
+|----------|-----------------|----------|----------|-------|------|
+| cholesky_decompose | 3×3 textbook SPD, L[0][0] | 2.0 | 2.00000000 | 0.00e+00 | ✅ |
+| cholesky_decompose | 3×3 textbook SPD, L[1][0] | 6.0 | 6.00000000 | 0.00e+00 | ✅ |
+| cholesky_decompose | 3×3 textbook SPD, L[1][1] | 1.0 | 1.00000000 | 0.00e+00 | ✅ |
+| cholesky_decompose | 3×3 textbook SPD, L[2][0] | -8.0 | -8.00000000 | 0.00e+00 | ✅ |
+| cholesky_decompose | 3×3 textbook SPD, L[2][1] | 5.0 | 5.00000000 | 0.00e+00 | ✅ |
+| cholesky_decompose | 3×3 textbook SPD, L[2][2] | 3.0 | 3.00000000 | 0.00e+00 | ✅ |
+
+### Performance
+
+| Function | N | Total | Per call |
+|----------|---|-------|----------|
+| cholesky_decompose 3×3 | 100,000 | 3,041 µs | 30 ns |
+
+**RESULTS: 6 PASS / 0 FAIL / 6 TOTAL** (Unity suite); validation-runner checks above match.
+
+---
+
+## Windows x64 - Windows 11 / MSVC 19.51.36248.0 (VS 2026 Build Tools) / float64
+**Validator:** Amir Ab Khoshk | **Date:** 2026-07-12 | **Commit:** 4dc881f
+
+> Built from the root CMakeLists.txt with `CMAKE_C_FLAGS="-DNUMX_USE_DOUBLE -DUNITY_INCLUDE_DOUBLE"`
+> passed on the command line, so `numx_real_t = double` throughout without editing any
+> existing CMake files. Confirmed a 64-bit x86-64 binary (PE32+) via
+> `file build_x64_f64/Release/numx_tests.exe`.
+
+### Test cases
+
+| Test | Result |
+|------|--------|
+| test_cholesky_decompose_3x3_success | ✅ |
+| test_cholesky_decompose_residual_reconstruction | ✅ |
+| test_cholesky_decompose_non_spd_fail | ✅ |
+| test_cholesky_decompose_null_A | ✅ |
+| test_cholesky_decompose_null_L | ✅ |
+| test_cholesky_decompose_invalid_dim | ✅ |
+
+*337 / 337 Unity tests PASS*
+
+### Validation-runner checks
+
+| Function | Input / scenario | Expected | Computed | Error | Pass |
+|----------|-----------------|----------|----------|-------|------|
+| cholesky_decompose | 3×3 textbook SPD, L[0][0] | 2.0 | 2.00000000 | 0.00e+00 | ✅ |
+| cholesky_decompose | 3×3 textbook SPD, L[1][0] | 6.0 | 6.00000000 | 0.00e+00 | ✅ |
+| cholesky_decompose | 3×3 textbook SPD, L[1][1] | 1.0 | 1.00000000 | 0.00e+00 | ✅ |
+| cholesky_decompose | 3×3 textbook SPD, L[2][0] | -8.0 | -8.00000000 | 0.00e+00 | ✅ |
+| cholesky_decompose | 3×3 textbook SPD, L[2][1] | 5.0 | 5.00000000 | 0.00e+00 | ✅ |
+| cholesky_decompose | 3×3 textbook SPD, L[2][2] | 3.0 | 3.00000000 | 0.00e+00 | ✅ |
+
+### Performance
+
+| Function | N | Total | Per call |
+|----------|---|-------|----------|
+| cholesky_decompose 3×3 | 100,000 | 2,794 µs | 27 ns |
+
+**RESULTS: 6 PASS / 0 FAIL / 6 TOTAL** (Unity suite); validation-runner checks above match.
+
+---
+
+## Linux x86 - Ubuntu 24.04.4 LTS (WSL2, kernel 6.18.33.2-microsoft-standard-WSL2) / gcc 13.3.0 (-m32, gcc-multilib) / float32
+**Validator:** Amir Ab Khoshk | **Date:** 2026-07-12 | **Commit:** 4dc881f
+
+> Configured with `CMAKE_C_FLAGS=-m32 CMAKE_EXE_LINKER_FLAGS=-m32` against the root
+> CMakeLists.txt, no existing files edited. Confirmed a 32-bit ELF binary via
+> `file build_wsl_x86/numx_tests` (`ELF 32-bit LSB pie executable, Intel 80386`).
+> Required `gcc-multilib`/`g++-multilib` to be installed in WSL first (installed by
+> the user with sudo, not by this session).
+
+### Test cases
+
+| Test | Result |
+|------|--------|
+| test_cholesky_decompose_3x3_success | ✅ |
+| test_cholesky_decompose_residual_reconstruction | ✅ |
+| test_cholesky_decompose_non_spd_fail | ✅ |
+| test_cholesky_decompose_null_A | ✅ |
+| test_cholesky_decompose_null_L | ✅ |
+| test_cholesky_decompose_invalid_dim | ✅ |
+
+*337 / 337 Unity tests PASS*
+
+### Validation-runner checks
+
+| Function | Input / scenario | Expected | Computed | Error | Pass |
+|----------|-----------------|----------|----------|-------|------|
+| cholesky_decompose | 3×3 textbook SPD, L[0][0] | 2.0 | 2.00000000 | 0.00e+00 | ✅ |
+| cholesky_decompose | 3×3 textbook SPD, L[1][0] | 6.0 | 6.00000000 | 0.00e+00 | ✅ |
+| cholesky_decompose | 3×3 textbook SPD, L[1][1] | 1.0 | 1.00000000 | 0.00e+00 | ✅ |
+| cholesky_decompose | 3×3 textbook SPD, L[2][0] | -8.0 | -8.00000000 | 0.00e+00 | ✅ |
+| cholesky_decompose | 3×3 textbook SPD, L[2][1] | 5.0 | 5.00000000 | 0.00e+00 | ✅ |
+| cholesky_decompose | 3×3 textbook SPD, L[2][2] | 3.0 | 3.00000000 | 0.00e+00 | ✅ |
+
+### Performance
+
+| Function | N | Total | Per call |
+|----------|---|-------|----------|
+| cholesky_decompose 3×3 | 100,000 | 4,129 µs | 41 ns |
+
+**RESULTS: 6 PASS / 0 FAIL / 6 TOTAL** (Unity suite); validation-runner checks above match.
+
+---
+
+## Linux x86-64 - Ubuntu 24.04.4 LTS (WSL2, kernel 6.18.33.2-microsoft-standard-WSL2) / gcc 13.3.0 / float64
+**Validator:** Amir Ab Khoshk | **Date:** 2026-07-12 | **Commit:** 4dc881f
+
+> Built from the root CMakeLists.txt with `CMAKE_C_FLAGS="-DNUMX_USE_DOUBLE -DUNITY_INCLUDE_DOUBLE"`
+> passed on the command line, no existing CMake files edited. `numx_tests`, `numx_val_runner`,
+> and `numx_bench` all build cleanly under float64 at this commit.
+
+### Test cases
+
+| Test | Result |
+|------|--------|
+| test_cholesky_decompose_3x3_success | ✅ |
+| test_cholesky_decompose_residual_reconstruction | ✅ |
+| test_cholesky_decompose_non_spd_fail | ✅ |
+| test_cholesky_decompose_null_A | ✅ |
+| test_cholesky_decompose_null_L | ✅ |
+| test_cholesky_decompose_invalid_dim | ✅ |
+
+*337 / 337 Unity tests PASS*
+
+### Validation-runner checks
+
+| Function | Input / scenario | Expected | Computed | Error | Pass |
+|----------|-----------------|----------|----------|-------|------|
+| cholesky_decompose | 3×3 textbook SPD, L[0][0] | 2.0 | 2.00000000 | 0.00e+00 | ✅ |
+| cholesky_decompose | 3×3 textbook SPD, L[1][0] | 6.0 | 6.00000000 | 0.00e+00 | ✅ |
+| cholesky_decompose | 3×3 textbook SPD, L[1][1] | 1.0 | 1.00000000 | 0.00e+00 | ✅ |
+| cholesky_decompose | 3×3 textbook SPD, L[2][0] | -8.0 | -8.00000000 | 0.00e+00 | ✅ |
+| cholesky_decompose | 3×3 textbook SPD, L[2][1] | 5.0 | 5.00000000 | 0.00e+00 | ✅ |
+| cholesky_decompose | 3×3 textbook SPD, L[2][2] | 3.0 | 3.00000000 | 0.00e+00 | ✅ |
+
+### Performance
+
+| Function | N | Total | Per call |
+|----------|---|-------|----------|
+| cholesky_decompose 3×3 | 100,000 | 4,652 µs | 46 ns |
+
+**RESULTS: 6 PASS / 0 FAIL / 6 TOTAL** (Unity suite); validation-runner checks above match.
+
+---
+
+## ARMv7 (armhf) — Raspbian GNU/Linux 13 (trixie) / Raspberry Pi 4 Model B / gcc 14.2.0 / float32
+**Validator:** Amir Ab Khoshk | **Date:** 2026-07-12 | **Commit:** 4dc881f
+
+> Validated over SSH (`sellol@raspberrypi.local`). Kernel is 64-bit
+> (`6.18.33+rpt-rpi-v8 aarch64`) but the OS userland/toolchain is 32-bit armhf
+> (`dpkg --print-architecture` → `armhf`), so the actual build output is ARMv7/EABI5,
+> not aarch64 — confirmed via `file build/numx_tests`
+> (`ELF 32-bit LSB executable, ARM, EABI5`). The working tree at commit 4dc881f was
+> copied to the Pi via `git archive` + SFTP into a fresh directory
+> (`~/numx_cholesky_validation`, separate from the existing `~/numx` clone, which was
+> behind on a different fork/branch) since the existing clone didn't yet have
+> `numx_cholesky_decompose`. Built from the root CMakeLists.txt, unmodified, Release
+> config.
+
+### Test cases
+
+| Test | Result |
+|------|--------|
+| test_cholesky_decompose_3x3_success | ✅ |
+| test_cholesky_decompose_residual_reconstruction | ✅ |
+| test_cholesky_decompose_non_spd_fail | ✅ |
+| test_cholesky_decompose_null_A | ✅ |
+| test_cholesky_decompose_null_L | ✅ |
+| test_cholesky_decompose_invalid_dim | ✅ |
+
+*337 / 337 Unity tests PASS*
+
+### Validation-runner checks
+
+| Function | Input / scenario | Expected | Computed | Error | Pass |
+|----------|-----------------|----------|----------|-------|------|
+| cholesky_decompose | 3×3 textbook SPD, L[0][0] | 2.0 | 2.00000000 | 0.00e+00 | ✅ |
+| cholesky_decompose | 3×3 textbook SPD, L[1][0] | 6.0 | 6.00000000 | 0.00e+00 | ✅ |
+| cholesky_decompose | 3×3 textbook SPD, L[1][1] | 1.0 | 1.00000000 | 0.00e+00 | ✅ |
+| cholesky_decompose | 3×3 textbook SPD, L[2][0] | -8.0 | -8.00000000 | 0.00e+00 | ✅ |
+| cholesky_decompose | 3×3 textbook SPD, L[2][1] | 5.0 | 5.00000000 | 0.00e+00 | ✅ |
+| cholesky_decompose | 3×3 textbook SPD, L[2][2] | 3.0 | 3.00000000 | 0.00e+00 | ✅ |
+
+### Performance
+
+| Function | N | Total | Per call |
+|----------|---|-------|----------|
+| cholesky_decompose 3×3 | 100,000 | 17,304 µs | 173 ns |
+
+**RESULTS: 6 PASS / 0 FAIL / 6 TOTAL** (Unity suite); validation-runner checks above match.
+
+---
+
+## ESP32-S3 - ESP-IDF v5.5.2 / Xtensa LX7 / xtensa-esp-elf-gcc 14.2.0 (esp-14.2.0) / float32
+**Validator:** Amir Ab Khoshk | **Date:** 2026-07-12 | **Commit:** 4dc881f
+
+> The existing on-device test harness (`tests/esp32_tests/`) has no `cholesky_decompose`
+> coverage, same gap the NTT module had. Rather than editing that harness (would require
+> touching `CMakeLists.txt`, `tests.h`, `esp32_tests.c`), a new self-contained example
+> project was created at `examples/esp32_cholesky_test/` (`CMakeLists.txt`,
+> `main/CMakeLists.txt`, `main/main.c`, `main/sdkconfig.defaults` — all new files, nothing
+> existing modified), mirroring the pattern already established at
+> `examples/esp32_ntt_test/`. It links `src/linalg.c` directly (self-contained, no other
+> numx source dependencies) and mirrors the 6 test cases in `tests/test_linalg.c`,
+> expanded into 23 individual value/status assertions (0 dependency on Unity). Built with
+> `idf.py set-target esp32s3` / `idf.py build`, flashed to a real ESP32-S3 DevKit over USB
+> (COM5, VID 303A) via `idf.py -p COM5 flash`, output captured over UART at 115200 baud.
+> Unlike the NTT run, no stack overflow / watchdog issue was observed — cholesky's 3×3
+> buffers are far smaller than NTT's 256-element `numx_q15_t` arrays, so the default
+> `CONFIG_ESP_MAIN_TASK_STACK_SIZE=8192` was sufficient and all 100,000 benchmark
+> iterations completed normally.
+
+### Test cases
+
+| Test | Result |
+|------|--------|
+| test_cholesky_decompose_3x3_success | ✅ |
+| test_cholesky_decompose_residual_reconstruction | ✅ |
+| test_cholesky_decompose_non_spd_fail | ✅ |
+| test_cholesky_decompose_null_A | ✅ |
+| test_cholesky_decompose_null_L | ✅ |
+| test_cholesky_decompose_invalid_dim | ✅ |
+
+*23 / 23 assertions PASS (6 test cases, expanded per-element/per-status-code)*
+
+### Performance
+
+| Function | N | Total | Per call |
+|----------|---|-------|----------|
+| cholesky_decompose 3×3 | 100,000 | 698,140 µs | 6,981 ns |
+
+**RESULTS: 23 PASS / 0 FAIL / 23 TOTAL**


### PR DESCRIPTION
## Summary
Completes the multi-platform validation sweep for `numx_cholesky_decompose` (originally added in #51), bringing it in line with every other function in `linalg`. Previously only one platform had been validated; this PR adds results for Windows x86/x64, Linux x86 (32-bit)/x86-64 (WSL2), Raspberry Pi 4 (armhf), and ESP32-S3.

## Changes
- Adds a new self-contained example project at `examples/esp32_cholesky_test/` (mirroring `examples/esp32_ntt_test/`), since the on-device ESP32 test harness had no Cholesky coverage. It links `src/linalg.c` directly and runs the six existing test cases plus a benchmark loop over UART.
- Adds `validation/prompts/cholesky_rpi_esp32_validation_prompt.md`, a self-contained task prompt documenting the workflow used to validate on the Raspberry Pi 4 and ESP32-S3.
- Appends six new platform sections to `validation/results/linalg/cholesky_decompose.md`: Windows x86 (float32), Windows x64 (float64), Linux x86 WSL2 (float32), Linux x86-64 WSL2 (float64), Raspberry Pi 4 armhf (float32), and ESP32-S3 (float32). Existing sections are left untouched; the old "Remaining validation" note is replaced with a completion summary.

## Results
All 6 Cholesky test cases and the corresponding validation-runner checks pass on every platform (337/337 Unity tests on the desktop/Pi builds, 23/23 assertions on the ESP32 harness), with zero failures.